### PR TITLE
[FIX/#25] Main / bottom navigation view 간격 및 아이콘 설정

### DIFF
--- a/app/src/main/java/com/yello/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/yello/presentation/main/MainActivity.kt
@@ -24,6 +24,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     private fun initBnvItemIconTintList() {
         binding.bnvMain.itemIconTintList = null
+        binding.bnvMain.selectedItemId = R.id.menu_yello
     }
 
     private fun initBnvItemSelectedListener() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,6 +13,7 @@
             android:id="@+id/fcv_main"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:layout_marginBottom="-10dp"
             app:layout_constraintBottom_toTopOf="@id/bnv_main"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_yello.xml
+++ b/app/src/main/res/layout/fragment_yello.xml
@@ -9,7 +9,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <!-- TODO: Update blank fragment layout -->
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
- closed #25 

## *⛳️ Work Description*
- Fragment Container View margin 지정
- Bottom Navigation View 초기 아이콘 설정

## *📸 Screenshot*
<img src="https://github.com/team-yello/YELLO-Android/assets/70993562/b34da4e2-30ca-4234-9874-e6932788d4fe" width=270 />

## *📢 To Reviewers*
- 프래그먼트 컨테이너 뷰에 -10dp를 지정해서 뷰 짤 때 고려해주세요!
- 바로 머지하겠습니다 ㅎㅎ
