### PR TITLE
[FIX/#107] 로그인, 회원가입 서버통신에 device token 추가

### DIFF
--- a/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
@@ -25,6 +25,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
     private lateinit var appLoginCallback: (OAuthToken?, Throwable?) -> Unit
     private lateinit var webLoginCallback: (OAuthToken?, Throwable?) -> Unit
     private lateinit var kakaoAccessToken: String
+    private lateinit var deviceToken: String
 
     private val viewModel by viewModels<SignInViewModel>()
 
@@ -32,7 +33,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
         super.onCreate(savedInstanceState)
 
         initSignInButtonListener()
-        viewModel.getDeviceToken()
+        setDeviceToken()
         observeKakaoUserDataState()
         observeChangeTokenState()
         observeUserDataExists()
@@ -46,6 +47,11 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
         }
     }
 
+    private fun setDeviceToken() {
+        viewModel.getDeviceToken()
+        deviceToken = viewModel.getDeviceTokenFromStore()
+    }
+
     // 웹에서 계정 로그인 callback 구성
     private fun setWebLoginCallback() {
         webLoginCallback = { token, error ->
@@ -56,7 +62,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
                 setKakaoAccessToken(token)
                 viewModel.changeTokenFromServer(
                     accessToken = kakaoAccessToken,
-                    deviceToken = viewModel.deviceToken
+                    deviceToken = deviceToken
                 )
             } else {
                 Timber.tag(TAG_AUTH).d(getString(R.string.sign_in_error_empty_kakao_token))
@@ -82,7 +88,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
                 setKakaoAccessToken(token)
                 viewModel.changeTokenFromServer(
                     accessToken = kakaoAccessToken,
-                    deviceToken = viewModel.deviceToken
+                    deviceToken = deviceToken
                 )
             } else {
                 Timber.tag(TAG_AUTH).d(getString(R.string.sign_in_error_empty_kakao_token))

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
@@ -2,6 +2,7 @@ package com.el.yello.presentation.auth
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import com.el.yello.R
 import com.el.yello.databinding.ActivitySignInBinding
@@ -33,7 +34,8 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
         super.onCreate(savedInstanceState)
 
         initSignInButtonListener()
-        setDeviceToken()
+        viewModel.getDeviceToken()
+        observeDeviceTokenState()
         observeKakaoUserDataState()
         observeChangeTokenState()
         observeUserDataExists()
@@ -45,11 +47,6 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
             setAppLoginCallback()
             startKakaoLogin()
         }
-    }
-
-    private fun setDeviceToken() {
-        viewModel.getDeviceToken()
-        deviceToken = viewModel.getDeviceTokenFromStore()
     }
 
     // 웹에서 계정 로그인 callback 구성
@@ -102,6 +99,25 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
             viewModel.loginWithAppCallback(this, appLoginCallback)
         } else {
             viewModel.loginWithWebCallback(this, webLoginCallback)
+        }
+    }
+
+    // Firebase에서 디바이스 토큰 받아와 저장
+    private fun observeDeviceTokenState() {
+        viewModel.getDeviceTokenState.observe(this) { state ->
+            when (state) {
+                is UiState.Success -> {
+                    deviceToken = state.data
+                }
+
+                is UiState.Failure -> {
+                    toast(getString(R.string.sign_in_error_connection))
+                }
+
+                is UiState.Loading -> {}
+
+                is UiState.Empty -> {}
+            }
         }
     }
 

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
@@ -2,7 +2,6 @@ package com.el.yello.presentation.auth
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.viewModels
 import com.el.yello.R
 import com.el.yello.databinding.ActivitySignInBinding

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
@@ -32,6 +32,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
         super.onCreate(savedInstanceState)
 
         initSignInButtonListener()
+        viewModel.getDeviceToken()
         observeKakaoUserDataState()
         observeChangeTokenState()
         observeUserDataExists()
@@ -53,7 +54,10 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
             } else if (token != null) {
                 // 로그인 성공 시 토큰 저장 & 토큰 교체 서버통신 진행
                 setKakaoAccessToken(token)
-                viewModel.changeTokenFromServer(kakaoAccessToken)
+                viewModel.changeTokenFromServer(
+                    accessToken = kakaoAccessToken,
+                    deviceToken = viewModel.deviceToken
+                )
             } else {
                 Timber.tag(TAG_AUTH).d(getString(R.string.sign_in_error_empty_kakao_token))
             }
@@ -76,7 +80,10 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
             } else if (token != null) {
                 // 로그인 성공 시 토큰 저장 & 토큰 교체 서버통신 진행
                 setKakaoAccessToken(token)
-                viewModel.changeTokenFromServer(kakaoAccessToken)
+                viewModel.changeTokenFromServer(
+                    accessToken = kakaoAccessToken,
+                    deviceToken = viewModel.deviceToken
+                )
             } else {
                 Timber.tag(TAG_AUTH).d(getString(R.string.sign_in_error_empty_kakao_token))
             }
@@ -97,7 +104,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
         viewModel.postState.observe(this) { state ->
             when (state) {
                 is UiState.Success -> {
-                    // 500(가입된 아이디): 온보딩 뷰 생략하고 바로 메인 화면으로 이동 위해 유저 정보 받기
+                    // 200(가입된 아이디): 온보딩 뷰 생략하고 바로 메인 화면으로 이동 위해 유저 정보 받기
                     viewModel.getUserData()
                 }
 

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
@@ -122,7 +122,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
 
     // 서비스 토큰 교체 서버 통신 결과에 따라서 분기 처리 진행
     private fun observeChangeTokenState() {
-        viewModel.postState.observe(this) { state ->
+        viewModel.postChangeTokenState.observe(this) { state ->
             when (state) {
                 is UiState.Success -> {
                     // 200(가입된 아이디): 온보딩 뷰 생략하고 바로 메인 화면으로 이동 위해 유저 정보 받기

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInViewModel.kt
@@ -1,24 +1,23 @@
 package com.el.yello.presentation.auth
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.el.yello.presentation.auth.SignInActivity.Companion.CODE_NOT_SIGNED_IN
+import com.el.yello.presentation.auth.SignInActivity.Companion.CODE_NO_UUID
 import com.example.domain.entity.RequestServiceTokenModel
 import com.example.domain.entity.ServiceTokenModel
 import com.example.domain.repository.AuthRepository
 import com.example.domain.repository.OnboardingRepository
 import com.example.domain.repository.ProfileRepository
 import com.example.ui.view.UiState
+import com.google.firebase.messaging.FirebaseMessaging
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.user.UserApiClient
 import com.kakao.sdk.user.model.User
 import dagger.hilt.android.lifecycle.HiltViewModel
-import com.el.yello.presentation.auth.SignInActivity.Companion.CODE_NOT_SIGNED_IN
-import com.el.yello.presentation.auth.SignInActivity.Companion.CODE_NO_UUID
-import com.google.firebase.messaging.FirebaseMessaging
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import javax.inject.Inject
@@ -132,6 +131,7 @@ class SignInViewModel @Inject constructor(
         }
     }
 
+    // 디바이스 토큰 FCM에서 받아 로컬에 저장
     fun getDeviceToken() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
             _getDeviceTokenState.value = UiState.Loading

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInViewModel.kt
@@ -1,6 +1,7 @@
 package com.el.yello.presentation.auth
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -37,6 +38,9 @@ class SignInViewModel @Inject constructor(
 
     private val _getKakaoDataState = MutableLiveData<UiState<User?>>()
     val getKakaoDataState: LiveData<UiState<User?>> = _getKakaoDataState
+
+    private val _getDeviceTokenState = MutableLiveData<UiState<String>>()
+    val getDeviceTokenState: LiveData<UiState<String>> = _getDeviceTokenState
 
     private val serviceTermsList = listOf(THUMBNAIL, EMAIL, FRIEND_LIST)
 
@@ -130,13 +134,15 @@ class SignInViewModel @Inject constructor(
 
     fun getDeviceToken() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+            _getDeviceTokenState.value = UiState.Loading
             if (task.isSuccessful) {
                 authRepository.setDeviceToken(task.result)
+                _getDeviceTokenState.value = UiState.Success(task.result)
+                return@addOnCompleteListener
             }
+            _getDeviceTokenState.value = UiState.Failure(task.result)
         }
     }
-
-    fun getDeviceTokenFromStore() = authRepository.getDeviceToken()
 
     private companion object {
         const val KAKAO = "KAKAO"

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInViewModel.kt
@@ -40,8 +40,6 @@ class SignInViewModel @Inject constructor(
 
     private val serviceTermsList = listOf(THUMBNAIL, EMAIL, FRIEND_LIST)
 
-    var deviceToken: String = ""
-
     // 웹 로그인 실행
     fun loginWithWebCallback(
         context: Context,
@@ -133,10 +131,12 @@ class SignInViewModel @Inject constructor(
     fun getDeviceToken() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
             if (task.isSuccessful) {
-                deviceToken = task.result
+                authRepository.setDeviceToken(task.result)
             }
         }
     }
+
+    fun getDeviceTokenFromStore() = authRepository.getDeviceToken()
 
     private companion object {
         const val KAKAO = "KAKAO"

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInViewModel.kt
@@ -29,8 +29,8 @@ class SignInViewModel @Inject constructor(
     private val profileRepository: ProfileRepository,
 ) : ViewModel() {
 
-    private val _postState = MutableLiveData<UiState<ServiceTokenModel?>>()
-    val postState: LiveData<UiState<ServiceTokenModel?>> = _postState
+    private val _postChangeTokenState = MutableLiveData<UiState<ServiceTokenModel?>>()
+    val postChangeTokenState: LiveData<UiState<ServiceTokenModel?>> = _postChangeTokenState
 
     private val _getUserProfileState = MutableLiveData<UiState<Unit>>()
     val getUserProfileState: LiveData<UiState<Unit>> = _getUserProfileState
@@ -86,25 +86,25 @@ class SignInViewModel @Inject constructor(
     // 서버통신 - 카카오 토큰 보내서 서비스 토큰 받아오기
     fun changeTokenFromServer(accessToken: String, social: String = KAKAO, deviceToken: String) {
         viewModelScope.launch {
-            _postState.value = UiState.Loading
+            _postChangeTokenState.value = UiState.Loading
             runCatching {
                 onboardingRepository.postTokenToServiceToken(
                     RequestServiceTokenModel(accessToken, social, deviceToken),
                 )
             }.onSuccess {
                 if (it == null) {
-                    _postState.value = UiState.Empty
+                    _postChangeTokenState.value = UiState.Empty
                     return@launch
                 }
                 authRepository.setAutoLogin(it.accessToken, it.refreshToken)
-                _postState.value = UiState.Success(it)
+                _postChangeTokenState.value = UiState.Success(it)
             }.onFailure {
                 if (it is HttpException && it.code() == 403) {
-                    _postState.value = UiState.Failure(CODE_NOT_SIGNED_IN)
+                    _postChangeTokenState.value = UiState.Failure(CODE_NOT_SIGNED_IN)
                 } else if (it is HttpException && it.code() == 404) {
-                    _postState.value = UiState.Failure(CODE_NO_UUID)
+                    _postChangeTokenState.value = UiState.Failure(CODE_NO_UUID)
                 } else {
-                    _postState.value = UiState.Failure("ERROR")
+                    _postChangeTokenState.value = UiState.Failure("ERROR")
                 }
             }
         }

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoViewModel.kt
@@ -105,5 +105,5 @@ class RecommendKakaoViewModel @Inject constructor(
         }
     }
 
-    fun getYelloId() = authRepository.getYelloId() ?: ""
+    fun getYelloId() = authRepository.getYelloId()
 }

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolFragment.kt
@@ -108,7 +108,7 @@ class RecommendSchoolFragment :
         viewModel.postFriendsListState.observe(viewLifecycleOwner) { state ->
             when (state) {
                 is UiState.Success -> {
-                    if (state.data?.friends?.isEmpty() == true && adapter?.itemCount == 0) {
+                    if (state.data?.friends?.isEmpty() == true && adapter.itemCount == 0) {
                         showNoFriendScreen()
                     } else {
                         showFriendListScreen()

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolViewModel.kt
@@ -74,5 +74,5 @@ class RecommendSchoolViewModel @Inject constructor(
         }
     }
 
-    fun getYelloId() = authRepository.getYelloId() ?: ""
+    fun getYelloId() = authRepository.getYelloId()
 }

--- a/app/src/main/java/com/el/yello/presentation/main/yello/YelloViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/yello/YelloViewModel.kt
@@ -97,7 +97,7 @@ class YelloViewModel @Inject constructor(
         }
     }
 
-    fun getYelloId() = authRepository.getYelloId() ?: ""
+    fun getYelloId() = authRepository.getYelloId()
 
     companion object {
         const val SEC_MAX_LOCK_TIME = 2400L

--- a/app/src/main/java/com/el/yello/presentation/onboarding/activity/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/onboarding/activity/OnBoardingViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
-import com.example.domain.entity.onboarding.RequestAddFriendModel
 import com.example.domain.entity.onboarding.AddFriendListModel
 import com.example.domain.entity.onboarding.GroupList
+import com.example.domain.entity.onboarding.RequestAddFriendModel
 import com.example.domain.entity.onboarding.SchoolList
 import com.example.domain.entity.onboarding.SignupInfo
 import com.example.domain.entity.onboarding.UserInfo
@@ -70,11 +70,10 @@ class OnBoardingViewModel @Inject constructor(
                 }
                 // totalSchoolPage = ceil((schoolList.totalCount * 0.1)).toInt()
                 // if (totalSchoolPage == schoolPage) isSchoolPagingFinish = true
-                _schoolData.value =
-                    when {
-                        schoolList.schoolList.isEmpty() -> UiState.Empty
-                        else -> UiState.Success(schoolList)
-                    }
+                _schoolData.value = when {
+                    schoolList.schoolList.isEmpty() -> UiState.Empty
+                    else -> UiState.Success(schoolList)
+                }
             }.onFailure { t ->
                 if (t is HttpException) {
                     Timber.e("GET SCHOOL LIST FAILURE : $t")
@@ -138,11 +137,10 @@ class OnBoardingViewModel @Inject constructor(
 
                 // totalDepartmentPage = ceil((department.totalCount * 0.1)).toLong()
                 // if (totalDepartmentPage == departmentPage) isDepartmentPagingFinish = true
-                _departmentData.value =
-                    when {
-                        groupList.groupList.isEmpty() -> UiState.Empty
-                        else -> UiState.Success(groupList)
-                    }
+                _departmentData.value = when {
+                    groupList.groupList.isEmpty() -> UiState.Empty
+                    else -> UiState.Success(groupList)
+                }
             }.onFailure { t ->
                 if (t is HttpException) {
                     Timber.e("GET GROUP LIST FAILURE : $t")
@@ -202,8 +200,7 @@ class OnBoardingViewModel @Inject constructor(
         currentFriendOffset += 100
         currentFriendPage += 1
         TalkApiClient.instance.friends(
-            offset = currentFriendOffset,
-            limit = 100
+            offset = currentFriendOffset, limit = 100
         ) { friends, error ->
             if (error != null) {
                 Timber.e(error, "카카오톡 친구목록 가져오기 실패")
@@ -224,8 +221,7 @@ class OnBoardingViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 onboardingRepository.postToGetFriendList(
-                    RequestAddFriendModel(friendKakaoId, groupId),
-                    0
+                    RequestAddFriendModel(friendKakaoId, groupId), 0
                 )
             }.onSuccess { friendList ->
                 friendList ?: return@launch
@@ -248,17 +244,14 @@ class OnBoardingViewModel @Inject constructor(
 
     fun getValidYelloId() {
         viewModelScope.launch {
-            onboardingRepository.getValidYelloId(yelloId = id)
-                .onSuccess { isValid ->
+            onboardingRepository.getValidYelloId(yelloId = id).onSuccess { isValid ->
                     Timber.d("GET VALID YELLO ID SUCCESS : $isValid")
                     if (isValid == null) {
                         _getValidYelloId.value = UiState.Empty
                         return@launch
                     }
-
                     _getValidYelloId.value = UiState.Success(isValid)
-                }
-                .onFailure { t ->
+                }.onFailure { t ->
                     if (t is HttpException) {
                         Timber.e("GET VALID YELLO ID FAILURE : $t")
                         _getValidYelloId.value = UiState.Failure(t.code().toString())
@@ -301,8 +294,7 @@ class OnBoardingViewModel @Inject constructor(
                 recommendId = recommendId,
                 deviceToken = deviceToken
             )
-            onboardingRepository.postSignup(signupInfo)
-                .onSuccess { userInfo ->
+            onboardingRepository.postSignup(signupInfo).onSuccess { userInfo ->
                     Timber.d("POST SIGN UP SUCCESS : $userInfo")
                     if (userInfo == null) {
                         _postSignupState.value = UiState.Empty
@@ -311,8 +303,7 @@ class OnBoardingViewModel @Inject constructor(
                     authRepository.setAutoLogin(userInfo.accessToken, userInfo.refreshToken)
                     authRepository.setYelloId(userInfo.yelloId)
                     _postSignupState.value = UiState.Success(userInfo)
-                }
-                .onFailure { t ->
+                }.onFailure { t ->
                     if (t is HttpException) {
                         Timber.e("POST SIGN UP FAILURE : $t")
                         _postSignupState.value = UiState.Failure(t.code().toString())

--- a/app/src/main/java/com/el/yello/presentation/onboarding/activity/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/onboarding/activity/OnBoardingViewModel.kt
@@ -287,6 +287,7 @@ class OnBoardingViewModel @Inject constructor(
 
     fun postSignup() {
         viewModelScope.launch {
+            val deviceToken = authRepository.getDeviceToken()
             val signupInfo = SignupInfo(
                 kakaoId = kakaoId,
                 email = email,
@@ -298,7 +299,7 @@ class OnBoardingViewModel @Inject constructor(
                 gender = gender,
                 friendList = selectedFriendIdList,
                 recommendId = recommendId,
-                deviceToken = authRepository.getDeviceToken()
+                deviceToken = deviceToken
             )
             onboardingRepository.postSignup(signupInfo)
                 .onSuccess { userInfo ->

--- a/app/src/main/java/com/el/yello/presentation/onboarding/activity/OnBoardingViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/onboarding/activity/OnBoardingViewModel.kt
@@ -298,6 +298,7 @@ class OnBoardingViewModel @Inject constructor(
                 gender = gender,
                 friendList = selectedFriendIdList,
                 recommendId = recommendId,
+                deviceToken = authRepository.getDeviceToken()
             )
             onboardingRepository.postSignup(signupInfo)
                 .onSuccess { userInfo ->

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -77,7 +77,6 @@ object ThirdPartyDependencies {
     const val kakaoAuth = "com.kakao.sdk:v2-auth:${Versions.kakaoVersion}"
     const val kakaoTalk = "com.kakao.sdk:v2-talk:${Versions.kakaoVersion}"
     const val kakaoShare = "com.kakao.sdk:v2-share:${Versions.kakaoVersion}"
-    // circle scale dot indicator
     const val circleIndicator = "me.relex:circleindicator:${Versions.circleIndicatorVersion}"
 }
 

--- a/data/src/main/java/com/example/data/local/YelloDataStoreImpl.kt
+++ b/data/src/main/java/com/example/data/local/YelloDataStoreImpl.kt
@@ -16,6 +16,10 @@ class YelloDataStoreImpl @Inject constructor(
         get() = dataStore.getString(PREF_REFRESH_TOKEN, "") ?: ""
         set(value) = dataStore.edit { putString(PREF_REFRESH_TOKEN, value) }
 
+    override var deviceToken: String
+        get() = dataStore.getString(PREF_DEVICE_TOKEN, "") ?: ""
+        set(value) = dataStore.edit { putString(PREF_DEVICE_TOKEN, value) }
+
     override var isLogin: Boolean
         get() = dataStore.getBoolean(PREF_IS_LOGIN, false)
         set(value) = dataStore.edit { putBoolean(PREF_IS_LOGIN, value) }
@@ -29,6 +33,7 @@ class YelloDataStoreImpl @Inject constructor(
     companion object {
         private const val PREF_USER_TOKEN = "USER_TOKEN"
         private const val PREF_REFRESH_TOKEN = "REFRESH_TOKEN"
+        private const val PREF_DEVICE_TOKEN = "DEVICE_TOKEN"
         private const val PREF_IS_LOGIN = "IS_LOGIN"
         private const val PREF_YELLO_ID = "YELLO_ID"
     }

--- a/data/src/main/java/com/example/data/model/request/onboarding/RequestPostSignupDto.kt
+++ b/data/src/main/java/com/example/data/model/request/onboarding/RequestPostSignupDto.kt
@@ -10,6 +10,8 @@ data class RequestPostSignupDto(
     val social: String,
     @SerialName("uuid")
     val uuid: String,
+    @SerialName("deviceToken")
+    val deviceToken: String,
     @SerialName("email")
     val email: String,
     @SerialName("profileImage")
@@ -42,4 +44,5 @@ fun SignupInfo.toRequestPostSignupDto() = RequestPostSignupDto(
     gender = gender,
     friends = friendList,
     recommendId = recommendId,
+    deviceToken = deviceToken
 )

--- a/data/src/main/java/com/example/data/model/request/onboarding/RequestServiceTokenDto.kt
+++ b/data/src/main/java/com/example/data/model/request/onboarding/RequestServiceTokenDto.kt
@@ -10,8 +10,10 @@ data class RequestServiceTokenDto(
     val accessToken: String,
     @SerialName("social")
     val social: String,
+    @SerialName("deviceToken")
+    val deviceToken: String
 )
 
 fun RequestServiceTokenModel.toRequestDto(): RequestServiceTokenDto {
-    return RequestServiceTokenDto(accessToken, social)
+    return RequestServiceTokenDto(accessToken, social, deviceToken)
 }

--- a/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
@@ -21,5 +21,11 @@ class AuthRepositoryImpl @Inject constructor(
 
     override fun getYelloId(): String = yelloDataStore.yelloId
 
+    override fun setDeviceToken(deviceToken: String) {
+        yelloDataStore.deviceToken = deviceToken
+    }
+
+    override fun getDeviceToken(): String = yelloDataStore.deviceToken
+
     override fun clearLocalPref() = yelloDataStore.clearLocalPref()
 }

--- a/domain/src/main/java/com/example/domain/YelloDataStore.kt
+++ b/domain/src/main/java/com/example/domain/YelloDataStore.kt
@@ -3,6 +3,7 @@ package com.example.domain
 interface YelloDataStore {
     var userToken: String
     var refreshToken: String
+    var deviceToken: String
     var isLogin: Boolean
     var yelloId: String
     fun clearLocalPref()

--- a/domain/src/main/java/com/example/domain/YelloDataStore.kt
+++ b/domain/src/main/java/com/example/domain/YelloDataStore.kt
@@ -6,5 +6,6 @@ interface YelloDataStore {
     var deviceToken: String
     var isLogin: Boolean
     var yelloId: String
+
     fun clearLocalPref()
 }

--- a/domain/src/main/java/com/example/domain/entity/RequestServiceTokenModel.kt
+++ b/domain/src/main/java/com/example/domain/entity/RequestServiceTokenModel.kt
@@ -3,4 +3,5 @@ package com.example.domain.entity
 data class RequestServiceTokenModel(
     val accessToken: String,
     val social: String,
+    val deviceToken: String
 )

--- a/domain/src/main/java/com/example/domain/entity/onboarding/SignupInfo.kt
+++ b/domain/src/main/java/com/example/domain/entity/onboarding/SignupInfo.kt
@@ -11,4 +11,5 @@ data class SignupInfo(
     val gender: String,
     val friendList: List<Long>,
     val recommendId: String? = null,
+    val deviceToken: String
 )

--- a/domain/src/main/java/com/example/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/example/domain/repository/AuthRepository.kt
@@ -4,6 +4,8 @@ interface AuthRepository {
     fun setAutoLogin(userToken: String, refreshToken: String)
     fun getAutoLogin(): Boolean
     fun setYelloId(yelloId: String)
-    fun getYelloId(): String?
+    fun getYelloId(): String
+    fun setDeviceToken(deviceToken: String)
+    fun getDeviceToken(): String
     fun clearLocalPref()
 }


### PR DESCRIPTION
- closed #107

## *⛳️ Work Description*
- 로그인 API 수정
- 회원가입 API 수정

## *📢 To Reviewers*
- 회원가입 API는 제 이슈 102번 PR 올려서 온보딩 이슈 수정까지 반영되어야 시도해볼 수 있어서 아직 못해봤습니다만
- 로직은 완벽구현 해뒀습니당
- 아마 일단 로그인에서만 잘 작동되면 이미 가입되어 있는 알람 담당 분들은 상관없다고 알고 있는데 맞죠?
- 102번 이슈 PR 올릴때 회원가입까지 완벽 구현 후 올릴게욥 
