### PR TITLE
[FIX/#175] 푸쉬 알림 권한 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,9 +5,11 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
-    <uses-permission android:name="com.google.android.play.billingclient.version"/>
+    <uses-permission android:name="com.google.android.play.billingclient.version" />
     <uses-permission android:name="com.android.vending.BILLING" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission
+        android:name="android.permission.POST_NOTIFICATIONS"
+        android:minSdkVersion="33" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/app/src/main/java/com/el/yello/presentation/main/yello/vote/note/NoteFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/yello/vote/note/NoteFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
+import com.amplitude.api.Identify
 import com.el.yello.R
 import com.el.yello.databinding.FragmentNoteBinding
 import com.el.yello.presentation.main.yello.vote.NoteState
@@ -30,6 +31,9 @@ class NoteFragment : BindingFragment<FragmentNoteBinding>(R.layout.fragment_note
     private var _voteListSize: Int? = null
     private val voteListSize
         get() = _voteListSize ?: 8
+
+
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -60,9 +64,12 @@ class NoteFragment : BindingFragment<FragmentNoteBinding>(R.layout.fragment_note
         }
 
         for (i in noteIndex + 1 until voteListSize) {
-            for (i in 1..8) {
-                val properties = JSONObject().put("vote_step", i)
-                AmplitudeUtils.trackEventWithProperties("view_vote_question", properties)
+            if (voteListSize in 1..8) {
+                if (noteIndex in 1..8) {
+                    val properties = JSONObject().put("vote_step", noteIndex)
+                    AmplitudeUtils.trackEventWithProperties("view_vote_question", properties)
+                    break
+                }
             }
             layoutInflater.inflate(
                 R.layout.layout_vote_progress_bar,
@@ -75,21 +82,21 @@ class NoteFragment : BindingFragment<FragmentNoteBinding>(R.layout.fragment_note
 
     private fun initShuffleBtnClickListener() {
         binding.btnNoteShuffle.setOnSingleClickListener {
-            for (i in 1..8) {
-                val properties = JSONObject().put("question_id", i)
+            viewModel.shuffle()
+            if (noteIndex in 1..8) {
+                val properties = JSONObject().put("question_id", noteIndex + 1)
                 AmplitudeUtils.trackEventWithProperties("click_vote_shuffle", properties)
             }
-            viewModel.shuffle()
         }
     }
 
     private fun initSkipBtnClickListener() {
         binding.btnNoteSkip.setOnSingleClickListener {
-            for (i in 1..8) {
-                val properties = JSONObject().put("question_id", i)
+            viewModel.skip()
+            if (noteIndex in 1..8) {
+                val properties = JSONObject().put("question_id", noteIndex + 1)
                 AmplitudeUtils.trackEventWithProperties("click_vote_skip", properties)
             }
-            viewModel.skip()
         }
     }
 

--- a/app/src/main/java/com/el/yello/presentation/onboarding/StartAppActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/onboarding/StartAppActivity.kt
@@ -1,10 +1,11 @@
 package com.el.yello.presentation.onboarding
 
+import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
-import androidx.core.app.ActivityCompat
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import com.el.yello.R
 import com.el.yello.databinding.ActivityStartAppBinding
@@ -18,8 +19,24 @@ class StartAppActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        askNotificationPermission()
         initTutorialView()
     }
+
+    private fun initTutorialView() {
+        binding.btnStartYello.setOnSingleClickListener {
+            AmplitudeUtils.trackEventWithProperties("click_onboarding_notification")
+        }
+    }
+
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+            if (isGranted) {
+                startTutorialActivity()
+            } else {
+                startTutorialActivity()
+            }
+        }
 
     private fun startTutorialActivity() {
         val intent = TutorialAActivity.newIntent(this, false).apply {
@@ -29,45 +46,20 @@ class StartAppActivity :
         finish()
     }
 
-    private fun initTutorialView() {
+    private fun askNotificationPermission() {
         binding.btnStartYello.setOnSingleClickListener {
-            AmplitudeUtils.trackEventWithProperties("click_onboarding_notification")
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 if (ContextCompat.checkSelfPermission(
                         this,
-                        android.Manifest.permission.POST_NOTIFICATIONS,
-                    ) != PackageManager.PERMISSION_GRANTED
+                        Manifest.permission.POST_NOTIFICATIONS,
+                    ) == PackageManager.PERMISSION_GRANTED
                 ) {
-                    ActivityCompat.requestPermissions(
-                        this,
-                        arrayOf(android.Manifest.permission.POST_NOTIFICATIONS),
-                        PERMISSION_REQUEST_CODE,
-                    )
+                } else if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                 } else {
-                    startTutorialActivity()
+                    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                 }
-            } else {
-                startTutorialActivity()
-            }
-            startTutorialActivity()
-        }
-    }
-
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray,
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == PERMISSION_REQUEST_CODE) {
-            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                startTutorialActivity()
-            } else {
             }
         }
-    }
-
-    companion object {
-        private const val PERMISSION_REQUEST_CODE = 1
     }
 }

--- a/app/src/main/java/com/el/yello/presentation/onboarding/fragment/startapp/StartAppFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/onboarding/fragment/startapp/StartAppFragment.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.view.View
+import androidx.activity.result.ActivityResultLauncher
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.el.yello.R
@@ -14,9 +15,9 @@ import com.el.yello.presentation.tutorial.TutorialAActivity
 import com.el.yello.util.amplitude.AmplitudeUtils
 import com.example.ui.base.BindingFragment
 import com.example.ui.view.setOnSingleClickListener
-import org.json.JSONObject
 
 class StartAppFragment : BindingFragment<FragmentStartAppBinding>(R.layout.fragment_start_app) {
+    private var requestPermissionLauncher: ActivityResultLauncher<String>? = null
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         (activity as? OnBoardingActivity)?.hideViews()

--- a/app/src/main/java/com/el/yello/util/amplitude/Amplitude.kt
+++ b/app/src/main/java/com/el/yello/util/amplitude/Amplitude.kt
@@ -1,6 +1,7 @@
 package com.el.yello.util.amplitude
 
 import com.amplitude.api.Amplitude
+import com.amplitude.api.Identify
 import org.json.JSONObject
 
 object AmplitudeUtils {

--- a/app/src/main/res/layout/activity_profile_quit_one.xml
+++ b/app/src/main/res/layout/activity_profile_quit_one.xml
@@ -39,6 +39,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
+            android:overScrollMode="never"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_profile_quit_for_sure_title">
 


### PR DESCRIPTION
- closed #175 

## *⛳️ Work Description*
- android13부터는 Notification 권한이 기본적으로 비활성화 상태로, 권한 설정을 해주었습니다.
- [x] 푸쉬 알람 설정 권한 이슈
- [x] 투표 amplitude 수정
- [x] 탈퇴뷰 overscroll 막기

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

## *📢 To Reviewers*
- @team-yello/andro-d 
