### PR TITLE
[FIX/#311] 셔플 및 키워드 오픈 직후 초성 오픈 이슈 해결

### DIFF
--- a/app/src/main/java/com/el/yello/presentation/main/myyello/read/MyYelloReadActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/myyello/read/MyYelloReadActivity.kt
@@ -226,8 +226,10 @@ class MyYelloReadActivity :
         viewModel.isFinishCheck.flowWithLifecycle(lifecycle)
             .onEach {
                 lifecycleScope.launch {
+                    if (!it) return@launch
                     delay(300)
-                    if (it) viewModel.getYelloDetail(id)
+                    viewModel.getYelloDetail(id)
+                    viewModel.setIsFinishCheck(false)
                 }
             }.launchIn(lifecycleScope)
     }

--- a/app/src/main/java/com/el/yello/presentation/main/myyello/read/MyYelloReadActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/myyello/read/MyYelloReadActivity.kt
@@ -97,7 +97,6 @@ class MyYelloReadActivity :
     private fun initClick() {
         binding.tvInitialCheck.setOnSingleClickListener {
             AmplitudeUtils.trackEventWithProperties("click_open_keyword")
-            viewModel.setIsFinishCheck(false)
             PointUseDialog.newInstance(
                 if (binding.tvInitialCheck.text.toString()
                         .contains("300")
@@ -153,7 +152,6 @@ class MyYelloReadActivity :
             } else {
                 AmplitudeUtils.trackEventWithProperties("click_open_fullname")
             }
-            viewModel.setIsFinishCheck(false)
             ReadingTicketUseDialog.newInstance(binding.tvKeywordNotYet.isGone)
                 .show(supportFragmentManager, "reading_ticket_dialog")
         }
@@ -220,16 +218,6 @@ class MyYelloReadActivity :
                     }
 
                     else -> {}
-                }
-            }.launchIn(lifecycleScope)
-
-        viewModel.isFinishCheck.flowWithLifecycle(lifecycle)
-            .onEach {
-                lifecycleScope.launch {
-                    if (!it) return@launch
-                    delay(300)
-                    viewModel.getYelloDetail(id)
-                    viewModel.setIsFinishCheck(false)
                 }
             }.launchIn(lifecycleScope)
     }

--- a/app/src/main/java/com/el/yello/presentation/main/myyello/read/MyYelloReadViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/myyello/read/MyYelloReadViewModel.kt
@@ -66,17 +66,12 @@ class MyYelloReadViewModel @Inject constructor(
         isTwoButton = isButton
     }
 
-    fun setMyPoint(point: Int) {
-        myPoint = point
-    }
-
     private fun minusPoint(): Int {
-        myPoint -= if (pointType == PointEnum.KEYWORD.ordinal) {
+        return if (pointType == PointEnum.KEYWORD.ordinal) {
             100
         } else {
             300
         }
-        return myPoint
     }
 
     private fun minusTicket() {

--- a/app/src/main/java/com/el/yello/presentation/main/myyello/read/MyYelloReadViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/myyello/read/MyYelloReadViewModel.kt
@@ -64,11 +64,12 @@ class MyYelloReadViewModel @Inject constructor(
     }
 
     private fun minusPoint(): Int {
-        return if (pointType == PointEnum.KEYWORD.ordinal) {
+        myPoint -= if (pointType == PointEnum.KEYWORD.ordinal) {
             100
         } else {
             300
         }
+        return myPoint
     }
 
     private fun minusTicket() {

--- a/app/src/main/java/com/el/yello/presentation/main/myyello/read/MyYelloReadViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/myyello/read/MyYelloReadViewModel.kt
@@ -30,9 +30,6 @@ class MyYelloReadViewModel @Inject constructor(
     private val _nameData = MutableStateFlow<UiState<CheckName>>(UiState.Loading)
     val nameData: StateFlow<UiState<CheckName>> = _nameData.asStateFlow()
 
-    private val _isFinishCheck = MutableStateFlow(false)
-    val isFinishCheck: StateFlow<Boolean> = _isFinishCheck.asStateFlow()
-
     private val _fullNameData = MutableStateFlow<UiState<FullName>>(UiState.Loading)
     val fullNameData: StateFlow<UiState<FullName>> = _fullNameData.asStateFlow()
 
@@ -78,11 +75,7 @@ class MyYelloReadViewModel @Inject constructor(
         myReadingTicketCount -= 1
     }
 
-    fun setIsFinishCheck(isFinish: Boolean) {
-        _isFinishCheck.value = isFinish
-    }
-
-    fun getYelloDetail(id: Long) {
+    fun getYelloDetail(id: Long = voteId) {
         voteId = id
         viewModelScope.launch {
             repository.getYelloDetail(id)

--- a/app/src/main/java/com/el/yello/presentation/main/myyello/read/PointAfterDialog.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/myyello/read/PointAfterDialog.kt
@@ -34,7 +34,6 @@ class PointAfterDialog :
     private fun initView() {
         if (viewModel.pointType == PointEnum.KEYWORD.ordinal) {
             viewModel.checkKeyword()
-
         } else {
             viewModel.checkInitial()
         }
@@ -65,7 +64,6 @@ class PointAfterDialog :
 
                     else -> {}
                 }
-
             }.launchIn(viewLifecycleOwner.lifecycleScope)
 
         viewModel.nameData.flowWithLifecycle(viewLifecycleOwner.lifecycle)
@@ -84,7 +82,6 @@ class PointAfterDialog :
 
                     else -> {}
                 }
-
             }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 
@@ -101,7 +98,7 @@ class PointAfterDialog :
         dialog?.window?.apply {
             setLayout(
                 (deviceWidth - dialogHorizontalMargin * 2).toInt(),
-                WindowManager.LayoutParams.WRAP_CONTENT
+                WindowManager.LayoutParams.WRAP_CONTENT,
             )
             setBackgroundDrawableResource(R.drawable.shape_fill_gray900_12dp)
         }

--- a/app/src/main/java/com/el/yello/presentation/main/myyello/read/PointAfterDialog.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/myyello/read/PointAfterDialog.kt
@@ -54,7 +54,7 @@ class PointAfterDialog :
                     is UiState.Success -> {
                         binding.tvPoint.text = viewModel.myPoint.toString()
                         binding.tvInitial.text = it.data.answer
-                        viewModel.setIsFinishCheck(true)
+                        viewModel.getYelloDetail()
                         viewModel.setHintUsed(true)
                     }
 
@@ -72,7 +72,7 @@ class PointAfterDialog :
                     is UiState.Success -> {
                         binding.tvPoint.text = viewModel.myPoint.toString()
                         binding.tvInitial.text = Utils.setChosungText(it.data.name, 0)
-                        viewModel.setIsFinishCheck(true)
+                        viewModel.getYelloDetail()
                         viewModel.setNameIndex(it.data.index)
                     }
 

--- a/app/src/main/java/com/el/yello/presentation/main/myyello/read/PointUseDialog.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/myyello/read/PointUseDialog.kt
@@ -14,7 +14,6 @@ import com.el.yello.util.amplitude.AmplitudeUtils
 import com.example.domain.enum.PointEnum
 import com.example.ui.base.BindingDialogFragment
 import com.example.ui.view.setOnSingleClickListener
-import org.json.JSONObject
 
 class PointUseDialog : BindingDialogFragment<DialogPointUseBinding>(R.layout.dialog_point_use) {
     private val viewModel by activityViewModels<MyYelloReadViewModel>()

--- a/app/src/main/java/com/el/yello/presentation/main/myyello/read/ReadingTicketAfterDialog.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/myyello/read/ReadingTicketAfterDialog.kt
@@ -40,7 +40,7 @@ class ReadingTicketAfterDialog :
                     is UiState.Success -> {
                         binding.tvKey.text = viewModel.myReadingTicketCount.toString()
                         binding.tvName.text = it.data.name
-                        viewModel.setIsFinishCheck(true)
+                        viewModel.getYelloDetail()
                         viewModel.setNameIndex(-2)
                     }
 

--- a/app/src/main/java/com/el/yello/presentation/main/yello/vote/VoteViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/yello/vote/VoteViewModel.kt
@@ -65,7 +65,7 @@ class VoteViewModel @Inject constructor(
     val choiceList: MutableList<Choice>
         get() = requireNotNull(_choiceList.value)
 
-    val _voteList = MutableStateFlow<List<Note>?>(null)
+    val _voteList = MutableLiveData<List<Note>>()
     val voteList: List<Note>
         get() = requireNotNull(_voteList.value)
 


### PR DESCRIPTION
- closed #311 

## *⛳️ Work Description*
- 셔플 동작하도록 로직 수정
- 구독 상태에서 초성 오픈되도록 수정

## *📸 Screenshot*
### Yello - 셔플
https://github.com/team-yello/YELLO-Android/assets/70993562/5828d02c-ce96-4e81-ac17-0359b91d4f86

### MyYelloRead - 초성 확인
https://github.com/team-yello/YELLO-Android/assets/70993562/0708c207-7b54-4c20-8676-bb6130d0698d

## *📢 To Reviewers*
- 플로우로 리스트 관리하려면 데바 쪽에 대형 공사가 필요해서 라이브데이터로 일단 다시 바꿔놨어요 ^_ㅠ
- MyYelloRead 부분에서 isFinish 변수를 없앴습니다!
