### PR TITLE
[REFACTOR/#349] 3차 스프린트 진입 전 코드 정리

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,8 +16,6 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
 
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
-
     <queries>
         <package android:name="com.instagram.android" />
     </queries>

--- a/app/src/main/java/com/el/yello/di/RetrofitModule.kt
+++ b/app/src/main/java/com/el/yello/di/RetrofitModule.kt
@@ -17,8 +17,10 @@ import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import org.json.JSONObject
 import retrofit2.Converter
 import retrofit2.Retrofit
+import timber.log.Timber
 import javax.inject.Singleton
 
 @Module
@@ -45,7 +47,21 @@ object RetrofitModule {
     @Provides
     @Singleton
     @Logger
-    fun provideHttpLoggingInterceptor(): Interceptor = HttpLoggingInterceptor().apply {
+    fun provideHttpLoggingInterceptor(): Interceptor = HttpLoggingInterceptor { message ->
+        when {
+            message.startsWith("{") && message.endsWith("}") -> {
+                Timber.tag("okhttp").d(JSONObject(message).toString(4))
+            }
+
+            message.startsWith("[") && message.endsWith("]") -> {
+                Timber.tag("okhttp").d(JSONObject(message).toString(4))
+            }
+
+            else -> {
+                Timber.tag("okhttp").d("CONNECTION INFO -> $message")
+            }
+        }
+    }.apply {
         level = HttpLoggingInterceptor.Level.BODY
     }
 

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
@@ -74,27 +74,8 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
 
     // 서비스 토큰 교체 서버 통신 결과에 따라서 분기 처리 진행
     private fun observeChangeTokenState() {
-        viewModel.postChangeTokenState.flowWithLifecycle(lifecycle).onEach { state ->
-            when (state) {
-                is UiState.Success -> {
-                    // 200(가입된 아이디): 온보딩 뷰 생략하고 바로 메인 화면으로 이동 위해 유저 정보 받기
-                    viewModel.getUserDataFromServer()
-                }
-
-                is UiState.Failure -> {
-                    if (state.msg == CODE_NOT_SIGNED_IN || state.msg == CODE_NO_UUID) {
-                        // 403, 404 : 온보딩 뷰로 이동 위해 카카오 유저 정보 얻기
-                        viewModel.getKakaoInfo()
-                    } else {
-                        // 나머지 : 에러 발생
-                        toast(getString(R.string.sign_in_error_connection))
-                    }
-                }
-
-                is UiState.Loading -> return@onEach
-
-                is UiState.Empty -> return@onEach
-            }
+        viewModel.postChangeTokenResult.flowWithLifecycle(lifecycle).onEach { result ->
+            if (!result) toast(getString(R.string.sign_in_error_connection))
         }.launchIn(lifecycleScope)
     }
 

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
@@ -38,7 +38,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
         viewModel.getDeviceToken()
         observeDeviceTokenError()
         observeAppLoginError()
-        observeKakaoUserInfoState()
+        observeKakaoUserInfoResult()
         observeFriendsListValidState()
         observeChangeTokenResult()
         observeUserDataState()
@@ -73,7 +73,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
     }
 
     // Failure -> 카카오에 등록된 유저 정보 받아온 후 친구목록 동의 화면으로 이동
-    private fun observeKakaoUserInfoState() {
+    private fun observeKakaoUserInfoResult() {
         viewModel.getKakaoInfoResult.flowWithLifecycle(lifecycle).onEach { result ->
             if (!result) yelloSnackbar(binding.root, getString(R.string.msg_error))
         }.launchIn(lifecycleScope)

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
@@ -44,11 +44,10 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
         observeUserDataState()
     }
 
-    // 카카오톡 앱 설치 유무에 따라 로그인 진행
     private fun initSignInBtnListener() {
         binding.btnSignIn.setOnSingleClickListener {
             AmplitudeUtils.trackEventWithProperties("click_onboarding_kakao")
-            viewModel.startKakaoLogIn(this)
+            viewModel.startLogInWithKakao(this)
         }
     }
 
@@ -58,27 +57,25 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
         }.launchIn(lifecycleScope)
     }
 
-    // 카카오통 앱 로그인에 실패한 경우 웹 로그인 시도
     private fun observeAppLoginError() {
         viewModel.isAppLoginAvailable.flowWithLifecycle(lifecycle).onEach { available ->
-            if (!available) viewModel.startKakaoLogIn(this)
+            if (!available) viewModel.startLogInWithKakao(this)
         }.launchIn(lifecycleScope)
     }
 
-    // 서비스 토큰 교체 서버 통신 결과에 따라서 분기 처리 진행
     private fun observeChangeTokenResult() {
         viewModel.postChangeTokenResult.flowWithLifecycle(lifecycle).onEach { result ->
             if (!result) toast(getString(R.string.sign_in_error_connection))
         }.launchIn(lifecycleScope)
     }
 
-    // Failure -> 카카오에 등록된 유저 정보 받아온 후 친구목록 동의 화면으로 이동
     private fun observeKakaoUserInfoResult() {
         viewModel.getKakaoInfoResult.flowWithLifecycle(lifecycle).onEach { result ->
             if (!result) yelloSnackbar(binding.root, getString(R.string.msg_error))
         }.launchIn(lifecycleScope)
     }
 
+    // ChangeToken Failure -> 카카오에 등록된 유저 정보 받아온 후 친구목록 동의 or 온보딩 화면으로 이동
     private fun observeFriendsListValidState() {
         viewModel.getKakaoValidState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
@@ -100,7 +97,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
         }.launchIn(lifecycleScope)
     }
 
-    // Success -> 서버에 등록된 유저 정보가 있는지 확인 후 메인 액티비티로 이동
+    // ChangeToken Success -> 서버에 등록된 유저 정보가 있는지 확인 후 메인 액티비티로 이동
     private fun observeUserDataState() {
         viewModel.getUserProfileState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInViewModel.kt
@@ -150,7 +150,10 @@ class SignInViewModel @Inject constructor(
             )
                 .onSuccess {
                     // 200(가입된 아이디): 온보딩 뷰 생략하고 바로 메인 화면으로 이동 위해 유저 정보 받기
-                    if (it == null) return@launch
+                    if (it == null) {
+                        _postChangeTokenResult.emit(false)
+                        return@launch
+                    }
                     authRepository.setAutoLogin(it.accessToken, it.refreshToken)
                     isResigned = it.isResigned
                     getUserDataFromServer()

--- a/app/src/main/java/com/el/yello/presentation/auth/SocialSyncActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SocialSyncActivity.kt
@@ -46,7 +46,7 @@ class SocialSyncActivity :
     private fun initSocialSyncBtnListener() {
         binding.btnSocialSync.setOnSingleClickListener {
             AmplitudeUtils.trackEventWithProperties("click_onboarding_kakao_friends")
-            viewModel.getKakaoFriendsList()
+            viewModel.getFriendsListFromKakao()
         }
     }
 
@@ -56,7 +56,6 @@ class SocialSyncActivity :
         }
     }
 
-    // 친구목록 동의만 받고 온보딩 뷰로 이동
     private fun observeFriendsAccessState() {
         viewModel.getFriendListState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {

--- a/app/src/main/java/com/el/yello/presentation/auth/SocialSyncActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SocialSyncActivity.kt
@@ -1,6 +1,7 @@
 package com.el.yello.presentation.auth
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.activity.viewModels
@@ -14,6 +15,7 @@ import com.el.yello.presentation.auth.SignInActivity.Companion.EXTRA_GENDER
 import com.el.yello.presentation.auth.SignInActivity.Companion.EXTRA_KAKAO_ID
 import com.el.yello.presentation.auth.SignInActivity.Companion.EXTRA_NAME
 import com.el.yello.presentation.auth.SignInActivity.Companion.EXTRA_PROFILE_IMAGE
+import com.el.yello.presentation.main.profile.manage.ProfileManageActivity.Companion.PRIVACY_URL
 import com.el.yello.presentation.onboarding.activity.EditNameActivity
 import com.el.yello.presentation.onboarding.fragment.checkName.CheckNameDialog
 import com.el.yello.util.amplitude.AmplitudeUtils
@@ -37,6 +39,7 @@ class SocialSyncActivity :
         super.onCreate(savedInstanceState)
 
         initSocialSyncBtnListener()
+        initSocialSyncTermsListener()
         observeFriendsAccessState()
     }
 
@@ -44,6 +47,12 @@ class SocialSyncActivity :
         binding.btnSocialSync.setOnSingleClickListener {
             AmplitudeUtils.trackEventWithProperties("click_onboarding_kakao_friends")
             viewModel.getKakaoFriendsList()
+        }
+    }
+
+    private fun initSocialSyncTermsListener() {
+        binding.btnSocialSyncTerms.setOnSingleClickListener {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(PRIVACY_URL)))
         }
     }
 

--- a/app/src/main/java/com/el/yello/presentation/auth/SocialSyncViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SocialSyncViewModel.kt
@@ -15,8 +15,7 @@ class SocialSyncViewModel @Inject constructor(
     private val _getFriendListState = MutableStateFlow<UiState<Unit>>(UiState.Empty)
     val getFriendListState: StateFlow<UiState<Unit>> = _getFriendListState
 
-    // 카카오 통신 - 카카오 친구목록 동의 받기
-    fun getKakaoFriendsList() {
+    fun getFriendsListFromKakao() {
         TalkApiClient.instance.friends { _, error ->
             _getFriendListState.value = UiState.Loading
             if (error == null) {

--- a/app/src/main/java/com/el/yello/presentation/main/dialog/InviteFriendDialog.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/dialog/InviteFriendDialog.kt
@@ -102,7 +102,6 @@ class InviteFriendDialog :
     }
 
     private fun startKakaoInvite(context: Context) {
-        // 카카오톡 설치 여부 확인
         if (ShareClient.instance.isKakaoTalkSharingAvailable(context)) {
             // 앱으로 공유
             ShareClient.instance.shareCustom(

--- a/app/src/main/java/com/el/yello/presentation/main/dialog/InviteFriendDialog.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/dialog/InviteFriendDialog.kt
@@ -103,37 +103,41 @@ class InviteFriendDialog :
 
     private fun startKakaoInvite(context: Context) {
         if (ShareClient.instance.isKakaoTalkSharingAvailable(context)) {
-            // 앱으로 공유
-            ShareClient.instance.shareCustom(
-                context,
-                templateId,
-                mapOf(KEY_YELLO_ID to myYelloId),
-            ) { sharingResult, error ->
-                if (error != null) {
-                    Timber.tag(TAG_SHARE).e(error, getString(R.string.invite_error_kakao))
-                } else if (sharingResult != null) {
-                    startActivity(sharingResult.intent)
-                }
-            }
+            shareKakaoWithApp(context)
         } else {
-            // 웹으로 공유
-            val sharerUrl = WebSharerClient.instance.makeCustomUrl(templateId)
+            shareKakaoWithWeb(context)
+        }
+    }
 
-            // 1. CustomTabsServiceConnection 지원 브라우저 - Chrome, 삼성 인터넷 등
-            try {
-                KakaoCustomTabsClient.openWithDefault(context, sharerUrl)
-                return
-            } catch (error: UnsupportedOperationException) {
-                Timber.tag(TAG_SHARE).e(error, getString(R.string.invite_error_browser))
+    private fun shareKakaoWithApp(context: Context) {
+        ShareClient.instance.shareCustom(
+            context,
+            templateId,
+            mapOf(KEY_YELLO_ID to myYelloId),
+        ) { sharingResult, error ->
+            if (error != null) {
+                Timber.tag(TAG_SHARE).e(error, getString(R.string.invite_error_kakao))
+            } else if (sharingResult != null) {
+                startActivity(sharingResult.intent)
             }
+        }
+    }
 
-            // 2. CustomTabsServiceConnection 미지원 브라우저 - 네이버 앱 등
-            try {
-                KakaoCustomTabsClient.open(context, sharerUrl)
-                return
-            } catch (error: ActivityNotFoundException) {
-                Timber.tag(TAG_SHARE).e(error, getString(R.string.invite_error_browser))
-            }
+    private fun shareKakaoWithWeb(context: Context) {
+        val sharerUrl = WebSharerClient.instance.makeCustomUrl(templateId)
+        // 1. CustomTabsServiceConnection 지원 브라우저 - Chrome, 삼성 인터넷 등
+        try {
+            KakaoCustomTabsClient.openWithDefault(context, sharerUrl)
+            return
+        } catch (error: UnsupportedOperationException) {
+            Timber.tag(TAG_SHARE).e(error, getString(R.string.invite_error_browser))
+        }
+        // 2. CustomTabsServiceConnection 미지원 브라우저 - 네이버 앱 등
+        try {
+            KakaoCustomTabsClient.open(context, sharerUrl)
+            return
+        } catch (error: ActivityNotFoundException) {
+            Timber.tag(TAG_SHARE).e(error, getString(R.string.invite_error_browser))
         }
     }
 

--- a/app/src/main/java/com/el/yello/presentation/main/look/LookFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/look/LookFragment.kt
@@ -160,6 +160,7 @@ class LookFragment : BindingFragment<FragmentLookBinding>(R.layout.fragment_look
     override fun onDestroyView() {
         super.onDestroyView()
         _adapter = null
+        if (inviteFriendDialog != null) inviteFriendDialog?.dismiss()
     }
 
     companion object {

--- a/app/src/main/java/com/el/yello/presentation/main/look/LookFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/look/LookFragment.kt
@@ -89,27 +89,27 @@ class LookFragment : BindingFragment<FragmentLookBinding>(R.layout.fragment_look
             }
             setPullToScrollColor(R.color.grayscales_500, R.color.grayscales_700)
         }
-        adapter.loadStateFlow.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+        adapter.loadStateFlow.flowWithLifecycle(lifecycle)
             .distinctUntilChangedBy { it.refresh }.onEach {
                 delay(200)
                 binding.layoutLookSwipe.isRefreshing = false
-            }.launchIn(viewLifecycleOwner.lifecycleScope)
+            }.launchIn(lifecycleScope)
     }
 
     private fun observeTimelinePagingList() {
-        viewModel.getLookListWithPaging().flowWithLifecycle(viewLifecycleOwner.lifecycle)
+        viewModel.getLookListWithPaging().flowWithLifecycle(lifecycle)
             .onEach { pagingData ->
                 adapter.submitData(lifecycle, pagingData)
-            }.launchIn(viewLifecycleOwner.lifecycleScope)
+            }.launchIn(lifecycleScope)
     }
 
 
     private fun observePagingLoadingState() {
-        adapter.loadStateFlow.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+        adapter.loadStateFlow.flowWithLifecycle(lifecycle)
             .onEach { loadStates ->
                 when (loadStates.refresh) {
                     is LoadState.Loading -> {
-                        if (!isNoFriend) startShimmerView()
+                        if (!isNoFriend) showShimmerView(true)
                     }
 
                     is LoadState.NotLoading -> {
@@ -117,15 +117,15 @@ class LookFragment : BindingFragment<FragmentLookBinding>(R.layout.fragment_look
                             startFadeIn()
                             viewModel.setFirstLoading(false)
                         }
-                        stopShimmerView()
+                        showShimmerView(false)
                     }
 
                     is LoadState.Error -> {
-                        startShimmerView()
+                        showShimmerView(true)
                         yelloSnackbar(requireView(), getString(R.string.look_error_friend_list))
                     }
                 }
-            }.launchIn(viewLifecycleOwner.lifecycleScope)
+            }.launchIn(lifecycleScope)
     }
 
     private fun catchScrollForAmplitude() {
@@ -145,19 +145,11 @@ class LookFragment : BindingFragment<FragmentLookBinding>(R.layout.fragment_look
         binding.rvLook.startAnimation(animation)
     }
 
-    private fun startShimmerView() {
+    private fun showShimmerView(isShown: Boolean) {
         with(binding) {
-            shimmerLookList.startShimmer()
-            shimmerLookList.isVisible = true
-            rvLook.isVisible = false
-        }
-    }
-
-    private fun stopShimmerView() {
-        with(binding) {
-            shimmerLookList.stopShimmer()
-            shimmerLookList.isVisible = false
-            rvLook.isVisible = true
+            if (isShown) shimmerLookList.startShimmer() else shimmerLookList.stopShimmer()
+            shimmerLookList.isVisible = isShown
+            rvLook.isVisible = !isShown
         }
     }
 

--- a/app/src/main/java/com/el/yello/presentation/main/look/LookViewHolder.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/look/LookViewHolder.kt
@@ -1,8 +1,6 @@
 package com.el.yello.presentation.main.look
 
-import android.view.View
-import android.widget.TextView
-import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import coil.transform.CircleCropTransformation
@@ -10,6 +8,8 @@ import com.el.yello.R
 import com.el.yello.databinding.ItemLookBinding
 import com.el.yello.presentation.main.profile.ProfileViewModel.Companion.BASIC_THUMBNAIL
 import com.example.domain.entity.LookListModel.LookModel
+import com.example.ui.context.colorOf
+import com.example.ui.context.drawableOf
 
 class LookViewHolder(
     val binding: ItemLookBinding
@@ -22,55 +22,43 @@ class LookViewHolder(
             tvNameHead.text = item.vote.nameHead
             tvNameFoot.text = item.vote.nameFoot
             tvKeywordHead.text = item.vote.keywordHead
-            tvKeyword.text = item.vote.keyword
             tvKeywordFoot.text = item.vote.keywordFoot
 
-            tvNameHead.visibility =
-                if (item.vote.nameHead.isNullOrEmpty()) View.GONE else View.VISIBLE
-            tvKeywordHead.visibility =
-                if (item.vote.keywordHead.isNullOrEmpty()) View.GONE else View.VISIBLE
+            tvNameHead.isVisible = !item.vote.nameHead.isNullOrEmpty()
+            tvKeywordHead.isVisible = !item.vote.keywordHead.isNullOrEmpty()
 
-        }
+            tvKeyword.apply {
+                text = item.vote.keyword
+                background =
+                    if (item.isHintUsed) null else itemView.context.drawableOf(R.drawable.shape_grayscales800_fill_grayscales700_dashline_4_rect)
+                setTextColor(
+                    itemView.context.colorOf(
+                        when {
+                            item.isHintUsed && item.senderGender == MALE -> R.color.semantic_gender_m_300
+                            item.isHintUsed && item.senderGender != MALE -> R.color.semantic_gender_f_300
+                            else -> R.color.grayscales_800
+                        }
+                    )
+                )
+            }
 
-        item.receiverProfileImage.let { thumbnail ->
-            if (thumbnail == BASIC_THUMBNAIL) {
-                binding.ivLookThumbnail.load(R.drawable.img_yello_basic)
-            } else {
-                binding.ivLookThumbnail.load(thumbnail) {
+            tvLookSendGender.apply {
+                text = if (item.senderGender == MALE) {
+                    setTextColor(itemView.context.colorOf(R.color.semantic_gender_m_500))
+                    FROM_MALE
+                } else {
+                    setTextColor(itemView.context.colorOf(R.color.semantic_gender_f_500))
+                    FROM_FEMALE
+                }
+            }
+
+            ivLookThumbnail.apply {
+                val thumbnail = item.receiverProfileImage
+                load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
                     transformations(CircleCropTransformation())
                 }
             }
         }
-
-        if (item.senderGender == MALE) {
-            setItemViewTextColor(binding.tvLookSendGender, R.color.semantic_gender_m_500)
-            binding.tvLookSendGender.text = FROM_MALE
-        } else {
-            setItemViewTextColor(binding.tvLookSendGender, R.color.semantic_gender_f_500)
-            binding.tvLookSendGender.text = FROM_FEMALE
-        }
-
-        if (item.isHintUsed) {
-            binding.tvKeyword.background = null
-            if (item.senderGender == MALE) {
-                setItemViewTextColor(binding.tvKeyword, R.color.semantic_gender_m_300)
-            } else {
-                setItemViewTextColor(binding.tvKeyword, R.color.semantic_gender_f_300)
-            }
-        } else {
-            binding.tvKeyword.background = ContextCompat.getDrawable(
-                itemView.context, R.drawable.shape_grayscales800_fill_grayscales700_dashline_4_rect
-            )
-            setItemViewTextColor(binding.tvKeyword, R.color.grayscales_800)
-        }
-    }
-
-    private fun setItemViewTextColor(textView: TextView, resourceId: Int) {
-        textView.setTextColor(
-            ContextCompat.getColor(
-                itemView.context, resourceId
-            )
-        )
     }
 
     private companion object {

--- a/app/src/main/java/com/el/yello/presentation/main/look/LookViewHolder.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/look/LookViewHolder.kt
@@ -2,11 +2,9 @@ package com.el.yello.presentation.main.look
 
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
-import coil.load
-import coil.transform.CircleCropTransformation
 import com.el.yello.R
 import com.el.yello.databinding.ItemLookBinding
-import com.el.yello.presentation.main.profile.ProfileViewModel.Companion.BASIC_THUMBNAIL
+import com.el.yello.util.Utils.setImageOrBasicThumbnail
 import com.example.domain.entity.LookListModel.LookModel
 import com.example.ui.context.colorOf
 import com.example.ui.context.drawableOf
@@ -26,6 +24,8 @@ class LookViewHolder(
 
             tvNameHead.isVisible = !item.vote.nameHead.isNullOrEmpty()
             tvKeywordHead.isVisible = !item.vote.keywordHead.isNullOrEmpty()
+
+            ivLookThumbnail.setImageOrBasicThumbnail(item.receiverProfileImage)
 
             tvKeyword.apply {
                 text = item.vote.keyword
@@ -49,13 +49,6 @@ class LookViewHolder(
                 } else {
                     setTextColor(itemView.context.colorOf(R.color.semantic_gender_f_500))
                     FROM_FEMALE
-                }
-            }
-
-            ivLookThumbnail.apply {
-                val thumbnail = item.receiverProfileImage
-                load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
-                    transformations(CircleCropTransformation())
                 }
             }
         }

--- a/app/src/main/java/com/el/yello/presentation/main/look/LookViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/look/LookViewModel.kt
@@ -29,12 +29,11 @@ class LookViewModel @Inject constructor(
         _isFirstLoading.value = boolean
     }
 
-    fun getLookListWithPaging(): Flow<PagingData<LookModel>> {
-        return Pager(
+    fun getLookListWithPaging(): Flow<PagingData<LookModel>> =
+        Pager(
             config = PagingConfig(LookPagingSource.LOOK_PAGE_SIZE),
             pagingSourceFactory = { LookPagingSource(lookService) }
         ).flow.cachedIn(viewModelScope)
-    }
 
     fun getYelloId() = authRepository.getYelloId()
 }

--- a/app/src/main/java/com/el/yello/presentation/main/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/ProfileViewModel.kt
@@ -248,9 +248,4 @@ class ProfileViewModel @Inject constructor(
             }.onFailure(Timber::e)
         }
     }
-
-    companion object {
-        const val BASIC_THUMBNAIL =
-            "https://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg"
-    }
 }

--- a/app/src/main/java/com/el/yello/presentation/main/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/ProfileViewModel.kt
@@ -98,7 +98,6 @@ class ProfileViewModel @Inject constructor(
         authRepository.setIsFirstLoginData()
     }
 
-    // 서버 통신 - 유저 정보 받아오기
     fun getUserDataFromServer() {
         viewModelScope.launch {
             profileRepository.getUserData()
@@ -115,7 +114,6 @@ class ProfileViewModel @Inject constructor(
         }
     }
 
-    // 서버 통신 - 친구 목록 정보 받아오기
     fun getFriendsListFromServer() {
         if (isPagingFinish) return
         if (isFirstScroll) {
@@ -139,7 +137,6 @@ class ProfileViewModel @Inject constructor(
         }
     }
 
-    // 서버 통신 - 회원 탈퇴
     fun deleteUserDataToServer() {
         viewModelScope.launch {
             _deleteUserState.value = UiState.Loading
@@ -155,7 +152,6 @@ class ProfileViewModel @Inject constructor(
         }
     }
 
-    // 서버 통신 - 친구 식제
     fun deleteFriendDataToServer(friendId: Long) {
         viewModelScope.launch {
             _deleteFriendState.value = UiState.Loading
@@ -169,7 +165,6 @@ class ProfileViewModel @Inject constructor(
         }
     }
 
-    // 카카오 SDK 통신 - 로그아웃
     fun logoutKakaoAccount() {
         UserApiClient.instance.logout { error ->
             _kakaoLogoutState.value = UiState.Loading
@@ -182,7 +177,6 @@ class ProfileViewModel @Inject constructor(
         }
     }
 
-    // 카카오 SDK 통신 - 회원 탈퇴
     fun quitKakaoAccount() {
         UserApiClient.instance.unlink { error ->
             _kakaoQuitState.value = UiState.Loading
@@ -194,7 +188,6 @@ class ProfileViewModel @Inject constructor(
         }
     }
 
-    // 서버 통신 - 구독 여부 & 열람권 개수 받아오기
     fun getPurchaseInfoFromServer() {
         viewModelScope.launch {
             payRepository.getPurchaseInfo()

--- a/app/src/main/java/com/el/yello/presentation/main/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/ProfileViewModel.kt
@@ -6,6 +6,7 @@ import com.el.yello.util.amplitude.AmplitudeUtils
 import com.example.domain.entity.PayInfoModel
 import com.example.domain.entity.ProfileFriendsListModel
 import com.example.domain.entity.ProfileUserModel
+import com.example.domain.entity.getEmptyProfileUserModel
 import com.example.domain.entity.vote.VoteCount
 import com.example.domain.repository.AuthRepository
 import com.example.domain.repository.PayRepository
@@ -66,10 +67,10 @@ class ProfileViewModel @Inject constructor(
     private var isPagingFinish = false
     private var totalPage = Int.MAX_VALUE
 
-    var myUserData = ProfileUserModel(0, "", "", "", "", 0, 0, 0)
+    var myUserData = getEmptyProfileUserModel()
     var myFriendCount = 0
 
-    var clickedUserData = ProfileUserModel(0, "", "", "", "", 0, 0, 0)
+    var clickedUserData = getEmptyProfileUserModel()
     var clickedItemPosition: Int? = null
 
     fun setItemPosition(position: Int) {

--- a/app/src/main/java/com/el/yello/presentation/main/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/ProfileViewModel.kt
@@ -6,7 +6,6 @@ import com.el.yello.util.amplitude.AmplitudeUtils
 import com.example.domain.entity.PayInfoModel
 import com.example.domain.entity.ProfileFriendsListModel
 import com.example.domain.entity.ProfileUserModel
-import com.example.domain.entity.getEmptyProfileUserModel
 import com.example.domain.entity.vote.VoteCount
 import com.example.domain.repository.AuthRepository
 import com.example.domain.repository.PayRepository
@@ -22,7 +21,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import retrofit2.HttpException
 import timber.log.Timber
 import javax.inject.Inject
 import kotlin.math.ceil
@@ -38,7 +36,8 @@ class ProfileViewModel @Inject constructor(
     private val _getUserDataResult = MutableSharedFlow<Boolean>()
     val getUserDataResult: SharedFlow<Boolean> = _getUserDataResult
 
-    private val _getFriendListState = MutableStateFlow<UiState<ProfileFriendsListModel>>(UiState.Empty)
+    private val _getFriendListState =
+        MutableStateFlow<UiState<ProfileFriendsListModel>>(UiState.Empty)
     val getFriendListState: StateFlow<UiState<ProfileFriendsListModel>> = _getFriendListState
 
     private val _deleteUserState = MutableStateFlow<UiState<Unit>>(UiState.Empty)
@@ -69,10 +68,10 @@ class ProfileViewModel @Inject constructor(
     private var isPagingFinish = false
     private var totalPage = Int.MAX_VALUE
 
-    var myUserData = getEmptyProfileUserModel()
+    var myUserData = ProfileUserModel()
     var myFriendCount = 0
 
-    var clickedUserData = getEmptyProfileUserModel()
+    var clickedUserData = ProfileUserModel()
     var clickedItemPosition: Int? = null
 
     fun setItemPosition(position: Int) {
@@ -216,7 +215,9 @@ class ProfileViewModel @Inject constructor(
         viewModelScope.launch {
             yelloRepository.voteCount()
                 .onSuccess {
-                    if (it != null) { _voteCount.value = UiState.Success(it) }
+                    if (it != null) {
+                        _voteCount.value = UiState.Success(it)
+                    }
                 }
                 .onFailure {
                     _voteCount.value = UiState.Failure(it.message.toString())

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFragment.kt
@@ -56,7 +56,7 @@ class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragmen
         initPullToScrollListener()
         setInfinityScroll()
         setDeleteAnimation()
-        observeUserDataState()
+        observeUserDataResult()
         observeFriendsDataState()
         observeFriendDeleteState()
         observeCheckIsSubscribed()
@@ -159,24 +159,9 @@ class ProfileFragment : BindingFragment<FragmentProfileBinding>(R.layout.fragmen
     }
 
     // 유저 정보 서버 통신 성공 시 어댑터 생성 후 리사이클러뷰에 부착
-    private fun observeUserDataState() {
-        viewModel.getUserDataState.flowWithLifecycle(lifecycle).onEach { state ->
-            when (state) {
-                is UiState.Success -> {
-                    viewModel.myUserData = state.data.apply {
-                        if (!this.yelloId.startsWith("@")) this.yelloId = "@" + this.yelloId
-                    }
-                    viewModel.myFriendCount = state.data.friendCount
-                }
-
-                is UiState.Failure -> {
-                    yelloSnackbar(requireView(), getString(R.string.profile_error_user_data))
-                }
-
-                is UiState.Empty -> return@onEach
-
-                is UiState.Loading -> return@onEach
-            }
+    private fun observeUserDataResult() {
+        viewModel.getUserDataResult.flowWithLifecycle(lifecycle).onEach { result ->
+            if (!result) yelloSnackbar(requireView(), getString(R.string.profile_error_user_data))
         }.launchIn(lifecycleScope)
     }
 

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendAdapter.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendAdapter.kt
@@ -21,24 +21,17 @@ class ProfileFriendAdapter(
     private var itemList = mutableListOf<ProfileUserModel>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val inflater by lazy { LayoutInflater.from(parent.context) }
         // 멀티뷰타입 구현 - 헤더 & 아이템 리스트
         return when (viewType) {
             VIEW_TYPE_USER_INFO -> ProfileUserInfoViewHolder(
-                ItemProfileUserInfoBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false,
-                ),
+                ItemProfileUserInfoBinding.inflate(inflater, parent, false),
                 buttonClick,
                 shopClick,
             )
 
             VIEW_TYPE_FRIENDS_LIST -> ProfileFriendsListViewHolder(
-                ItemProfileFriendsListBinding.inflate(
-                    LayoutInflater.from(parent.context),
-                    parent,
-                    false,
-                ),
+                ItemProfileFriendsListBinding.inflate(inflater, parent, false),
                 itemClick,
             )
 
@@ -67,16 +60,13 @@ class ProfileFriendAdapter(
         holder.itemView.layoutParams = layoutParams
     }
 
-    override fun getItemCount(): Int {
-        return itemList.size + HEADER_COUNT
-    }
+    override fun getItemCount() = itemList.size + HEADER_COUNT
 
-    override fun getItemViewType(position: Int): Int {
-        return when (position) {
+    override fun getItemViewType(position: Int) =
+        when (position) {
             0 -> VIEW_TYPE_USER_INFO
             else -> VIEW_TYPE_FRIENDS_LIST
         }
-    }
 
     fun addItemList(newItems: List<ProfileUserModel>) {
         this.itemList.addAll(newItems)

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendAdapter.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendAdapter.kt
@@ -22,7 +22,7 @@ class ProfileFriendAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater by lazy { LayoutInflater.from(parent.context) }
-        // 멀티뷰타입 구현 - 헤더 & 아이템 리스트
+
         return when (viewType) {
             VIEW_TYPE_USER_INFO -> ProfileUserInfoViewHolder(
                 ItemProfileUserInfoBinding.inflate(inflater, parent, false),

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendDeleteBottomSheet.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendDeleteBottomSheet.kt
@@ -10,6 +10,7 @@ import coil.transform.CircleCropTransformation
 import com.el.yello.R
 import com.el.yello.databinding.FragmentProfileDeleteBottomSheetBinding
 import com.el.yello.presentation.main.profile.ProfileViewModel
+import com.el.yello.presentation.main.profile.ProfileViewModel.Companion.BASIC_THUMBNAIL
 import com.example.ui.base.BindingBottomSheetDialog
 import com.example.ui.fragment.toast
 import com.example.ui.view.UiState
@@ -38,10 +39,9 @@ class ProfileFriendDeleteBottomSheet :
     }
 
     private fun setItemImage() {
-        if (viewModel.clickedUserData.profileImageUrl == ProfileViewModel.BASIC_THUMBNAIL) {
-            binding.ivProfileFriendDeleteThumbnail.load(R.drawable.img_yello_basic)
-        } else {
-            binding.ivProfileFriendDeleteThumbnail.load(viewModel.clickedUserData.profileImageUrl) {
+        binding.ivProfileFriendDeleteThumbnail.apply {
+            val thumbnail = viewModel.clickedUserData.profileImageUrl
+            load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
                 transformations(CircleCropTransformation())
             }
         }
@@ -63,7 +63,7 @@ class ProfileFriendDeleteBottomSheet :
 
     // 친구 삭제 서버 통신 성공 시 토스트 띄우고 바텀시트 종료
     private fun observeFriendDeleteState() {
-        viewModel.deleteFriendState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+        viewModel.deleteFriendState.flowWithLifecycle(lifecycle)
             .onEach { state ->
                 when (state) {
                     is UiState.Success -> {
@@ -83,6 +83,6 @@ class ProfileFriendDeleteBottomSheet :
 
                     is UiState.Empty -> return@onEach
                 }
-            }.launchIn(viewLifecycleOwner.lifecycleScope)
+            }.launchIn(lifecycleScope)
     }
 }

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendDeleteBottomSheet.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendDeleteBottomSheet.kt
@@ -5,12 +5,10 @@ import android.view.View
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import coil.load
-import coil.transform.CircleCropTransformation
 import com.el.yello.R
 import com.el.yello.databinding.FragmentProfileDeleteBottomSheetBinding
 import com.el.yello.presentation.main.profile.ProfileViewModel
-import com.el.yello.presentation.main.profile.ProfileViewModel.Companion.BASIC_THUMBNAIL
+import com.el.yello.util.Utils.setImageOrBasicThumbnail
 import com.example.ui.base.BindingBottomSheetDialog
 import com.example.ui.fragment.toast
 import com.example.ui.view.UiState
@@ -39,12 +37,7 @@ class ProfileFriendDeleteBottomSheet :
     }
 
     private fun setItemImage() {
-        binding.ivProfileFriendDeleteThumbnail.apply {
-            val thumbnail = viewModel.clickedUserData.profileImageUrl
-            load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
-                transformations(CircleCropTransformation())
-            }
-        }
+        binding.ivProfileFriendDeleteThumbnail.setImageOrBasicThumbnail(viewModel.clickedUserData.profileImageUrl)
     }
 
     private fun initReturnBtnListener() {
@@ -63,8 +56,7 @@ class ProfileFriendDeleteBottomSheet :
 
     // 친구 삭제 서버 통신 성공 시 토스트 띄우고 바텀시트 종료
     private fun observeFriendDeleteState() {
-        viewModel.deleteFriendState.flowWithLifecycle(lifecycle)
-            .onEach { state ->
+        viewModel.deleteFriendState.flowWithLifecycle(lifecycle).onEach { state ->
                 when (state) {
                     is UiState.Success -> {
                         toast(

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendDeleteBottomSheet.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendDeleteBottomSheet.kt
@@ -54,7 +54,6 @@ class ProfileFriendDeleteBottomSheet :
         }
     }
 
-    // 친구 삭제 서버 통신 성공 시 토스트 띄우고 바텀시트 종료
     private fun observeFriendDeleteState() {
         viewModel.deleteFriendState.flowWithLifecycle(lifecycle).onEach { state ->
                 when (state) {

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendItemBottomSheet.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendItemBottomSheet.kt
@@ -4,12 +4,10 @@ import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
-import coil.load
-import coil.transform.CircleCropTransformation
 import com.el.yello.R
 import com.el.yello.databinding.FragmentProfileItemBottomSheetBinding
 import com.el.yello.presentation.main.profile.ProfileViewModel
-import com.el.yello.presentation.main.profile.ProfileViewModel.Companion.BASIC_THUMBNAIL
+import com.el.yello.util.Utils.setImageOrBasicThumbnail
 import com.example.ui.base.BindingBottomSheetDialog
 import com.example.ui.view.setOnSingleClickListener
 
@@ -35,12 +33,7 @@ class ProfileFriendItemBottomSheet :
     }
 
     private fun setItemImage() {
-        binding.ivProfileFriendThumbnail.apply {
-            val thumbnail = viewModel.clickedUserData.profileImageUrl
-            load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
-                transformations(CircleCropTransformation())
-            }
-        }
+        binding.ivProfileFriendThumbnail.setImageOrBasicThumbnail(viewModel.clickedUserData.profileImageUrl)
     }
 
     // 다음 바텀시트 출력

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendItemBottomSheet.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendItemBottomSheet.kt
@@ -36,7 +36,6 @@ class ProfileFriendItemBottomSheet :
         binding.ivProfileFriendThumbnail.setImageOrBasicThumbnail(viewModel.clickedUserData.profileImageUrl)
     }
 
-    // 다음 바텀시트 출력
     private fun initDeleteBtnListener() {
         binding.btnProfileFriendDelete.setOnSingleClickListener {
             deleteBottomSheet?.show(parentFragmentManager, DELETE_BOTTOM_SHEET)

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendItemBottomSheet.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendItemBottomSheet.kt
@@ -35,10 +35,9 @@ class ProfileFriendItemBottomSheet :
     }
 
     private fun setItemImage() {
-        if (viewModel.clickedUserData.profileImageUrl == BASIC_THUMBNAIL) {
-            binding.ivProfileFriendThumbnail.load(R.drawable.img_yello_basic)
-        } else {
-            binding.ivProfileFriendThumbnail.load(viewModel.clickedUserData.profileImageUrl) {
+        binding.ivProfileFriendThumbnail.apply {
+            val thumbnail = viewModel.clickedUserData.profileImageUrl
+            load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
                 transformations(CircleCropTransformation())
             }
         }

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendsListViewHolder.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendsListViewHolder.kt
@@ -1,11 +1,8 @@
 package com.el.yello.presentation.main.profile.info
 
 import androidx.recyclerview.widget.RecyclerView
-import coil.load
-import coil.transform.CircleCropTransformation
-import com.el.yello.R
 import com.el.yello.databinding.ItemProfileFriendsListBinding
-import com.el.yello.presentation.main.profile.ProfileViewModel.Companion.BASIC_THUMBNAIL
+import com.el.yello.util.Utils.setImageOrBasicThumbnail
 import com.example.domain.entity.ProfileUserModel
 import com.example.ui.view.setOnSingleClickListener
 
@@ -20,12 +17,7 @@ class ProfileFriendsListViewHolder(
             tvProfileFriendItemName.text = item.name
             tvProfileFriendItemSchool.text = item.group
 
-            ivProfileFriendItemThumbnail.apply {
-                val thumbnail = item.profileImageUrl
-                load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
-                    transformations(CircleCropTransformation())
-                }
-            }
+            ivProfileFriendItemThumbnail.setImageOrBasicThumbnail(item.profileImageUrl)
 
             root.setOnSingleClickListener {
                 itemClick(item, position)

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendsListViewHolder.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileFriendsListViewHolder.kt
@@ -16,20 +16,20 @@ class ProfileFriendsListViewHolder(
     RecyclerView.ViewHolder(binding.root) {
 
     fun onBind(item: ProfileUserModel, position: Int) {
-        binding.tvProfileFriendItemName.text = item.name
-        binding.tvProfileFriendItemSchool.text = item.group
-        item.profileImageUrl.let { thumbnail ->
-            if (thumbnail == BASIC_THUMBNAIL) {
-                binding.ivProfileFriendItemThumbnail.load(R.drawable.img_yello_basic)
-            } else {
-                binding.ivProfileFriendItemThumbnail.load(thumbnail) {
+        with(binding) {
+            tvProfileFriendItemName.text = item.name
+            tvProfileFriendItemSchool.text = item.group
+
+            ivProfileFriendItemThumbnail.apply {
+                val thumbnail = item.profileImageUrl
+                load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
                     transformations(CircleCropTransformation())
                 }
             }
-        }
 
-        binding.root.setOnSingleClickListener {
-            itemClick(item, position)
+            root.setOnSingleClickListener {
+                itemClick(item, position)
+            }
         }
     }
 }

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileUserInfoViewHolder.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileUserInfoViewHolder.kt
@@ -2,12 +2,9 @@ package com.el.yello.presentation.main.profile.info
 
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
-import coil.load
-import coil.transform.CircleCropTransformation
-import com.el.yello.R
 import com.el.yello.databinding.ItemProfileUserInfoBinding
 import com.el.yello.presentation.main.profile.ProfileViewModel
-import com.el.yello.presentation.main.profile.ProfileViewModel.Companion.BASIC_THUMBNAIL
+import com.el.yello.util.Utils.setImageOrBasicThumbnail
 import com.example.ui.view.setOnSingleClickListener
 
 class ProfileUserInfoViewHolder(
@@ -26,12 +23,7 @@ class ProfileUserInfoViewHolder(
             btnProfileShop.setOnSingleClickListener { shopClick(viewModel) }
             btnProfileShopSale.setOnSingleClickListener { shopClick(viewModel) }
 
-            ivProfileInfoThumbnail.apply {
-                val thumbnail = viewModel.myUserData.profileImageUrl
-                load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
-                    transformations(CircleCropTransformation())
-                }
-            }
+            ivProfileInfoThumbnail.setImageOrBasicThumbnail(viewModel.myUserData.profileImageUrl)
         }
     }
 }

--- a/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileUserInfoViewHolder.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/profile/info/ProfileUserInfoViewHolder.kt
@@ -17,18 +17,20 @@ class ProfileUserInfoViewHolder(
 ) : RecyclerView.ViewHolder(binding.root) {
 
     fun onBind(viewModel: ProfileViewModel) {
-        binding.vm = viewModel
-        binding.ivSubsStar.isVisible = viewModel.isSubscribed
-        binding.ivSubsLine.isVisible = viewModel.isSubscribed
-        binding.btnProfileAddGroup.setOnSingleClickListener { buttonClick(viewModel) }
-        binding.btnProfileShop.setOnSingleClickListener { shopClick(viewModel) }
-        binding.btnProfileShopSale.setOnSingleClickListener { shopClick(viewModel) }
+        with(binding) {
+            vm = viewModel
+            ivSubsStar.isVisible = viewModel.isSubscribed
+            ivSubsLine.isVisible = viewModel.isSubscribed
 
-        if (viewModel.myUserData.profileImageUrl == BASIC_THUMBNAIL) {
-            binding.ivProfileInfoThumbnail.load(R.drawable.img_yello_basic)
-        } else {
-            binding.ivProfileInfoThumbnail.load(viewModel.myUserData.profileImageUrl) {
-                transformations(CircleCropTransformation())
+            btnProfileAddGroup.setOnSingleClickListener { buttonClick(viewModel) }
+            btnProfileShop.setOnSingleClickListener { shopClick(viewModel) }
+            btnProfileShopSale.setOnSingleClickListener { shopClick(viewModel) }
+
+            ivProfileInfoThumbnail.apply {
+                val thumbnail = viewModel.myUserData.profileImageUrl
+                load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
+                    transformations(CircleCropTransformation())
+                }
             }
         }
     }

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKaKaoViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKaKaoViewModel.kt
@@ -6,7 +6,6 @@ import com.el.yello.presentation.main.recommend.list.RecommendViewHolder
 import com.example.domain.entity.RecommendListModel
 import com.example.domain.entity.RecommendRequestModel
 import com.example.domain.entity.RecommendUserInfoModel
-import com.example.domain.entity.setEmptyRecommendUserInfoModel
 import com.example.domain.repository.AuthRepository
 import com.example.domain.repository.RecommendRepository
 import com.example.ui.view.UiState
@@ -41,7 +40,7 @@ class RecommendKakaoViewModel @Inject constructor(
 
     var itemPosition: Int? = null
     var itemHolder: RecommendViewHolder? = null
-    var clickedUserData = setEmptyRecommendUserInfoModel()
+    var clickedUserData = RecommendUserInfoModel()
 
     private var currentOffset = -100
     private var currentPage = -1

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKaKaoViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKaKaoViewModel.kt
@@ -68,8 +68,7 @@ class RecommendKakaoViewModel @Inject constructor(
         _getKakaoErrorResult.value = false
     }
 
-    // 서버 통신 - 카카오 리스트 통신 후 친구 리스트 추가 서버 통신 진행
-    fun addListWithKakaoIdList() {
+    fun getIdListFromKakao() {
         if (isPagingFinish) return
         currentOffset += 100
         currentPage += 1
@@ -83,15 +82,14 @@ class RecommendKakaoViewModel @Inject constructor(
             } else if (friends != null) {
                 totalPage = ceil((friends.totalCount * 0.01)).toInt() - 1
                 if (totalPage == currentPage) isPagingFinish = true
-                getListFromServer(
+                getFriendsListFromServer(
                     friends.elements?.map { friend -> friend.id.toString() } ?: listOf(),
                 )
             }
         }
     }
 
-    // 서버 통신 - 추천 친구 리스트 추가
-    private fun getListFromServer(friendsKakaoId: List<String>) {
+    private fun getFriendsListFromServer(friendsKakaoId: List<String>) {
         viewModelScope.launch {
             recommendRepository.postToGetKakaoFriendList(
                 0,
@@ -107,7 +105,6 @@ class RecommendKakaoViewModel @Inject constructor(
         }
     }
 
-    // 서버 통신 - 친구 추가
     fun addFriendToServer(friendId: Long) {
         _addFriendState.value = UiState.Loading
         viewModelScope.launch {
@@ -121,7 +118,6 @@ class RecommendKakaoViewModel @Inject constructor(
         }
     }
 
-    // 서버 통신 - 특정 유저 정보 받아오기
     fun getUserDataFromServer(userId: Long) {
         viewModelScope.launch {
             _getUserDataState.value = UiState.Loading

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKaKaoViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKaKaoViewModel.kt
@@ -6,6 +6,7 @@ import com.el.yello.presentation.main.recommend.list.RecommendViewHolder
 import com.example.domain.entity.RecommendListModel
 import com.example.domain.entity.RecommendRequestModel
 import com.example.domain.entity.RecommendUserInfoModel
+import com.example.domain.entity.setEmptyRecommendUserInfoModel
 import com.example.domain.repository.AuthRepository
 import com.example.domain.repository.RecommendRepository
 import com.example.ui.view.UiState
@@ -40,7 +41,7 @@ class RecommendKakaoViewModel @Inject constructor(
 
     var itemPosition: Int? = null
     var itemHolder: RecommendViewHolder? = null
-    var clickedUserData = RecommendUserInfoModel(0, "", "", "", "", 0, 0)
+    var clickedUserData = setEmptyRecommendUserInfoModel()
 
     private var currentOffset = -100
     private var currentPage = -1

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoBottomSheet.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoBottomSheet.kt
@@ -33,10 +33,9 @@ class RecommendKakaoBottomSheet :
     }
 
     private fun setItemImage() {
-        if (viewModel.clickedUserData.profileImageUrl == ProfileViewModel.BASIC_THUMBNAIL) {
-            binding.ivRecommendFriendThumbnail.load(R.drawable.img_yello_basic)
-        } else {
-            binding.ivRecommendFriendThumbnail.load(viewModel.clickedUserData.profileImageUrl) {
+        binding.ivRecommendFriendThumbnail.apply {
+            val thumbnail = viewModel.clickedUserData.profileImageUrl
+            load(if (thumbnail == ProfileViewModel.BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
                 transformations(CircleCropTransformation())
             }
         }

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoBottomSheet.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoBottomSheet.kt
@@ -4,11 +4,9 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
-import coil.load
-import coil.transform.CircleCropTransformation
 import com.el.yello.R
 import com.el.yello.databinding.FragmentRecommendKakaoItemBottomSheetBinding
-import com.el.yello.presentation.main.profile.ProfileViewModel
+import com.el.yello.util.Utils.setImageOrBasicThumbnail
 import com.example.ui.base.BindingBottomSheetDialog
 import com.example.ui.view.setOnSingleClickListener
 import kotlinx.coroutines.delay
@@ -33,12 +31,7 @@ class RecommendKakaoBottomSheet :
     }
 
     private fun setItemImage() {
-        binding.ivRecommendFriendThumbnail.apply {
-            val thumbnail = viewModel.clickedUserData.profileImageUrl
-            load(if (thumbnail == ProfileViewModel.BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
-                transformations(CircleCropTransformation())
-            }
-        }
+        binding.ivRecommendFriendThumbnail.setImageOrBasicThumbnail(viewModel.clickedUserData.profileImageUrl)
     }
 
     private fun initAddBtnListener() {

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoFragment.kt
@@ -290,8 +290,8 @@ class RecommendKakaoFragment :
 
     private fun changeToCheckIcon(holder: RecommendViewHolder) {
         with(holder.binding) {
-            btnRecommendItemAdd.isVisible = false
-            btnRecommendItemAddPressed.isVisible = true
+            btnRecommendItemAdd.visibility = View.INVISIBLE
+            btnRecommendItemAddPressed.visibility = View.VISIBLE
         }
     }
 

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoFragment.kt
@@ -46,6 +46,8 @@ class RecommendKakaoFragment :
     private var inviteNoFriendDialog: InviteFriendDialog? = null
     private var lastClickedRecommendModel: RecommendListModel.RecommendFriend? = null
 
+    private var recommendKakaoBottomSheet: RecommendKakaoBottomSheet? = null
+
     private lateinit var itemDivider: RecommendItemDecoration
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -165,48 +167,46 @@ class RecommendKakaoFragment :
     }
 
     private fun observeKakaoError() {
-        viewModel.getKakaoErrorResult.flowWithLifecycle(viewLifecycleOwner.lifecycle)
-            .onEach { result ->
-                if (result) {
-                    yelloSnackbar(requireView(), getString(R.string.recommend_error_friends_list))
-                    showShimmerScreen()
-                }
-            }.launchIn(viewLifecycleOwner.lifecycleScope)
+        viewModel.getKakaoErrorResult.flowWithLifecycle(lifecycle).onEach { result ->
+            if (result) {
+                yelloSnackbar(requireView(), getString(R.string.recommend_error_friends_list))
+                showShimmerView(isLoading = true, hasList = true)
+            }
+        }.launchIn(lifecycleScope)
     }
 
     // 추천친구 리스트 추가 서버 통신 성공 시 어댑터에 리스트 추가
     private fun observeAddListState() {
-        viewModel.postFriendsListState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
-            .onEach { state ->
-                when (state) {
-                    is UiState.Success -> {
-                        startFadeIn()
-                        if (state.data.friends.isEmpty() && adapter.itemCount == 0) {
-                            showNoFriendScreen()
-                        } else {
-                            showFriendListScreen()
-                            adapter.addItemList(state.data.friends)
-                        }
+        viewModel.postFriendsListState.flowWithLifecycle(lifecycle).onEach { state ->
+            when (state) {
+                is UiState.Success -> {
+                    startFadeIn()
+                    if (state.data.friends.isEmpty() && adapter.itemCount == 0) {
+                        showShimmerView(isLoading = false, hasList = false)
+                    } else {
+                        showShimmerView(isLoading = false, hasList = true)
+                        adapter.addItemList(state.data.friends)
                     }
-
-                    is UiState.Failure -> {
-                        showShimmerScreen()
-                        yelloSnackbar(
-                            requireView(),
-                            getString(R.string.recommend_error_friend_connection),
-                        )
-                    }
-
-                    is UiState.Loading -> showShimmerScreen()
-
-                    is UiState.Empty -> return@onEach
                 }
-            }.launchIn(viewLifecycleOwner.lifecycleScope)
+
+                is UiState.Failure -> {
+                    showShimmerView(isLoading = true, hasList = true)
+                    yelloSnackbar(
+                        requireView(),
+                        getString(R.string.recommend_error_friend_connection),
+                    )
+                }
+
+                is UiState.Loading -> showShimmerView(isLoading = true, hasList = true)
+
+                is UiState.Empty -> return@onEach
+            }
+        }.launchIn(lifecycleScope)
     }
 
     // 친구 추가 서버 통신 성공 시 리스트에서 아이템 삭제 & 서버 통신 중 액티비티 클릭 방지
     private fun observeAddFriendState() {
-        viewModel.addFriendState.flowWithLifecycle(viewLifecycleOwner.lifecycle).onEach { state ->
+        viewModel.addFriendState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
                 is UiState.Success -> {
                     val position = viewModel.itemPosition
@@ -235,20 +235,19 @@ class RecommendKakaoFragment :
 
                 is UiState.Empty -> return@onEach
             }
-        }.launchIn(viewLifecycleOwner.lifecycleScope)
+        }.launchIn(lifecycleScope)
     }
+
     private fun observeUserDataState() {
-        viewModel.getUserDataState.flowWithLifecycle(viewLifecycleOwner.lifecycle).onEach { state ->
+        viewModel.getUserDataState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
                 is UiState.Success -> {
                     viewModel.clickedUserData = state.data.apply {
                         if (!this.yelloId.startsWith("@")) this.yelloId = "@" + this.yelloId
                     }
                     if (lastClickedRecommendModel != null) {
-                        RecommendKakaoBottomSheet().show(
-                            parentFragmentManager,
-                            ITEM_BOTTOM_SHEET,
-                        )
+                        recommendKakaoBottomSheet = RecommendKakaoBottomSheet()
+                        recommendKakaoBottomSheet?.show(parentFragmentManager, ITEM_BOTTOM_SHEET)
                     }
                 }
 
@@ -260,8 +259,9 @@ class RecommendKakaoFragment :
 
                 is UiState.Loading -> return@onEach
             }
-        }.launchIn(viewLifecycleOwner.lifecycleScope)
+        }.launchIn(lifecycleScope)
     }
+
     private fun setDeleteAnimation() {
         binding.rvRecommendKakao.itemAnimator = object : DefaultItemAnimator() {
             override fun animateRemove(holder: RecyclerView.ViewHolder): Boolean {
@@ -270,11 +270,6 @@ class RecommendKakaoFragment :
                 return super.animateRemove(holder)
             }
         }
-    }
-
-    private fun dismissDialog() {
-        if (inviteYesFriendDialog?.isAdded == true) inviteYesFriendDialog?.dismiss()
-        if (inviteNoFriendDialog?.isAdded == true) inviteNoFriendDialog?.dismiss()
     }
 
     // 삭제 시 체크 버튼으로 전환 후 0.3초 뒤 애니메이션 적용
@@ -288,15 +283,15 @@ class RecommendKakaoFragment :
             binding.rvRecommendKakao.addItemDecoration(itemDivider)
             activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
             if (adapter.itemCount == 0) {
-                showNoFriendScreen()
+                showShimmerView(isLoading = false, hasList = false)
             }
         }
     }
 
     private fun changeToCheckIcon(holder: RecommendViewHolder) {
         with(holder.binding) {
-            btnRecommendItemAdd.visibility = View.INVISIBLE
-            btnRecommendItemAddPressed.visibility = View.VISIBLE
+            btnRecommendItemAdd.isVisible = false
+            btnRecommendItemAddPressed.isVisible = true
         }
     }
 
@@ -305,31 +300,13 @@ class RecommendKakaoFragment :
         binding.rvRecommendKakao.startAnimation(animation)
     }
 
-    private fun showShimmerScreen() {
+    private fun showShimmerView(isLoading: Boolean, hasList: Boolean) {
         with(binding) {
-            layoutRecommendFriendsList.isVisible = true
-            layoutRecommendNoFriendsList.isVisible = false
-            shimmerFriendList.startShimmer()
-            shimmerFriendList.isVisible = true
-            rvRecommendKakao.isVisible = false
-        }
-    }
-
-    private fun showFriendListScreen() {
-        with(binding) {
-            layoutRecommendFriendsList.isVisible = true
-            layoutRecommendNoFriendsList.isVisible = false
-            shimmerFriendList.startShimmer()
-            shimmerFriendList.isVisible = false
-            rvRecommendKakao.isVisible = true
-        }
-    }
-
-    private fun showNoFriendScreen() {
-        with(binding) {
-            layoutRecommendFriendsList.isVisible = false
-            layoutRecommendNoFriendsList.isVisible = true
-            shimmerFriendList.stopShimmer()
+            if (isLoading) shimmerFriendList.startShimmer() else shimmerFriendList.stopShimmer()
+            layoutRecommendFriendsList.isVisible = hasList
+            layoutRecommendNoFriendsList.isVisible = !hasList
+            shimmerFriendList.isVisible = isLoading
+            rvRecommendKakao.isVisible = !isLoading
         }
     }
 
@@ -340,7 +317,9 @@ class RecommendKakaoFragment :
     override fun onDestroyView() {
         super.onDestroyView()
         _adapter = null
-        dismissDialog()
+        if (inviteYesFriendDialog?.isAdded == true) inviteYesFriendDialog?.dismiss()
+        if (inviteNoFriendDialog?.isAdded == true) inviteNoFriendDialog?.dismiss()
+        if (recommendKakaoBottomSheet != null) recommendKakaoBottomSheet?.dismiss()
     }
 
     private companion object {

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/kakao/RecommendKakaoFragment.kt
@@ -59,7 +59,7 @@ class RecommendKakaoFragment :
         setKakaoRecommendList()
         setAdapterWithClickListener()
         observeUserDataState()
-        observeAddListState()
+        observeAddFriendsListState()
         observeAddFriendState()
         observeKakaoError()
         setItemDecoration()
@@ -82,16 +82,14 @@ class RecommendKakaoFragment :
         viewModel.isSearchViewShowed = false
     }
 
-    // 서버 통신 성공 시 카카오 추천 친구 추가
     private fun setKakaoRecommendList() {
         with(viewModel) {
             setFirstPageLoading()
             initViewModelVariable()
-            addListWithKakaoIdList()
+            getIdListFromKakao()
         }
     }
 
-    // 무한 스크롤 구현
     private fun setInfinityScroll() {
         binding.rvRecommendKakao.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
@@ -99,7 +97,7 @@ class RecommendKakaoFragment :
                 if (dy > 0) {
                     recyclerView.layoutManager?.let { layoutManager ->
                         if (!binding.rvRecommendKakao.canScrollVertically(1) && layoutManager is LinearLayoutManager && layoutManager.findLastVisibleItemPosition() == adapter.itemCount - 1) {
-                            viewModel.addListWithKakaoIdList()
+                            viewModel.getIdListFromKakao()
                         }
                     }
                 }
@@ -149,7 +147,6 @@ class RecommendKakaoFragment :
         binding.rvRecommendKakao.addItemDecoration(BaseLinearRcvItemDeco(bottomPadding = 12))
     }
 
-    // 어댑터 클릭 리스너 설정
     private fun setAdapterWithClickListener() {
         _adapter = RecommendAdapter(
             buttonClick = { recommendModel, position, holder ->
@@ -175,8 +172,7 @@ class RecommendKakaoFragment :
         }.launchIn(lifecycleScope)
     }
 
-    // 추천친구 리스트 추가 서버 통신 성공 시 어댑터에 리스트 추가
-    private fun observeAddListState() {
+    private fun observeAddFriendsListState() {
         viewModel.postFriendsListState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
                 is UiState.Success -> {
@@ -204,7 +200,6 @@ class RecommendKakaoFragment :
         }.launchIn(lifecycleScope)
     }
 
-    // 친구 추가 서버 통신 성공 시 리스트에서 아이템 삭제 & 서버 통신 중 액티비티 클릭 방지
     private fun observeAddFriendState() {
         viewModel.addFriendState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
@@ -272,7 +267,6 @@ class RecommendKakaoFragment :
         }
     }
 
-    // 삭제 시 체크 버튼으로 전환 후 0.3초 뒤 애니메이션 적용
     private fun removeItemWithAnimation(holder: RecommendViewHolder, position: Int) {
         lifecycleScope.launch {
             changeToCheckIcon(holder)

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/list/RecommendViewHolder.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/list/RecommendViewHolder.kt
@@ -1,11 +1,8 @@
 package com.el.yello.presentation.main.recommend.list
 
 import androidx.recyclerview.widget.RecyclerView
-import coil.load
-import coil.transform.CircleCropTransformation
-import com.el.yello.R
 import com.el.yello.databinding.ItemRecommendListBinding
-import com.el.yello.presentation.main.profile.ProfileViewModel.Companion.BASIC_THUMBNAIL
+import com.el.yello.util.Utils.setImageOrBasicThumbnail
 import com.example.domain.entity.RecommendListModel.RecommendFriend
 import com.example.ui.view.setOnSingleClickListener
 
@@ -13,19 +10,14 @@ class RecommendViewHolder(
     val binding: ItemRecommendListBinding,
     private val buttonClick: (RecommendFriend, Int, RecommendViewHolder) -> Unit,
     private val itemClick: (RecommendFriend, Int, RecommendViewHolder) -> (Unit),
-    ) : RecyclerView.ViewHolder(binding.root) {
+) : RecyclerView.ViewHolder(binding.root) {
 
     fun onBind(item: RecommendFriend, position: Int) {
         with(binding) {
             tvRecommendItemName.text = item.name
             tvRecommendItemSchool.text = item.group
 
-            ivRecommendItemThumbnail.apply {
-                val thumbnail = item.profileImage
-                load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
-                    transformations(CircleCropTransformation())
-                }
-            }
+            ivRecommendItemThumbnail.setImageOrBasicThumbnail(item.profileImage.orEmpty())
 
             btnRecommendItemAdd.setOnSingleClickListener {
                 buttonClick(item, position, this@RecommendViewHolder)

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/list/RecommendViewHolder.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/list/RecommendViewHolder.kt
@@ -13,29 +13,27 @@ class RecommendViewHolder(
     val binding: ItemRecommendListBinding,
     private val buttonClick: (RecommendFriend, Int, RecommendViewHolder) -> Unit,
     private val itemClick: (RecommendFriend, Int, RecommendViewHolder) -> (Unit),
-
-) :
-    RecyclerView.ViewHolder(binding.root) {
+    ) : RecyclerView.ViewHolder(binding.root) {
 
     fun onBind(item: RecommendFriend, position: Int) {
-        binding.tvRecommendItemName.text = item.name
-        binding.tvRecommendItemSchool.text = item.group
-        item.profileImage.let { thumbnail ->
-            if (thumbnail == BASIC_THUMBNAIL) {
-                binding.ivRecommendItemThumbnail.load(R.drawable.img_yello_basic)
-            } else {
-                binding.ivRecommendItemThumbnail.load(thumbnail) {
+        with(binding) {
+            tvRecommendItemName.text = item.name
+            tvRecommendItemSchool.text = item.group
+
+            ivRecommendItemThumbnail.apply {
+                val thumbnail = item.profileImage
+                load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
                     transformations(CircleCropTransformation())
                 }
             }
-        }
 
-        binding.btnRecommendItemAdd.setOnSingleClickListener {
-            buttonClick(item, position, this)
-        }
+            btnRecommendItemAdd.setOnSingleClickListener {
+                buttonClick(item, position, this@RecommendViewHolder)
+            }
 
-        binding.root.setOnSingleClickListener {
-            itemClick(item, position, this)
+            root.setOnSingleClickListener {
+                itemClick(item, position, this@RecommendViewHolder)
+            }
         }
     }
 }

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolBottomSheet.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolBottomSheet.kt
@@ -2,13 +2,14 @@ package com.el.yello.presentation.main.recommend.school
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import coil.load
 import coil.transform.CircleCropTransformation
 import com.el.yello.R
 import com.el.yello.databinding.FragmentRecommendSchoolItemBottomSheetBinding
-import com.el.yello.presentation.main.profile.ProfileViewModel
+import com.el.yello.presentation.main.profile.ProfileViewModel.Companion.BASIC_THUMBNAIL
 import com.example.ui.base.BindingBottomSheetDialog
 import com.example.ui.view.setOnSingleClickListener
 import kotlinx.coroutines.delay
@@ -33,10 +34,9 @@ class RecommendSchoolBottomSheet :
     }
 
     private fun setItemImage() {
-        if (viewModel.clickedUserData.profileImageUrl == ProfileViewModel.BASIC_THUMBNAIL) {
-            binding.ivRecommendFriendThumbnail.load(R.drawable.img_yello_basic)
-        } else {
-            binding.ivRecommendFriendThumbnail.load(viewModel.clickedUserData.profileImageUrl) {
+        binding.ivRecommendFriendThumbnail.apply {
+            val thumbnail = viewModel.clickedUserData.profileImageUrl
+            load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
                 transformations(CircleCropTransformation())
             }
         }
@@ -44,8 +44,8 @@ class RecommendSchoolBottomSheet :
 
     private fun initAddBtnListener() {
         binding.btnRecommendFriendAdd.setOnSingleClickListener {
-            binding.btnRecommendFriendAdd.visibility = View.INVISIBLE
-            binding.btnRecommendItemAddPressed.visibility = View.VISIBLE
+            binding.btnRecommendFriendAdd.isVisible = false
+            binding.btnRecommendItemAddPressed.isVisible = true
             lifecycleScope.launch {
                 viewModel.addFriendToServer(viewModel.clickedUserData.userId)
                 delay(300)

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolBottomSheet.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolBottomSheet.kt
@@ -5,11 +5,9 @@ import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
-import coil.load
-import coil.transform.CircleCropTransformation
 import com.el.yello.R
 import com.el.yello.databinding.FragmentRecommendSchoolItemBottomSheetBinding
-import com.el.yello.presentation.main.profile.ProfileViewModel.Companion.BASIC_THUMBNAIL
+import com.el.yello.util.Utils.setImageOrBasicThumbnail
 import com.example.ui.base.BindingBottomSheetDialog
 import com.example.ui.view.setOnSingleClickListener
 import kotlinx.coroutines.delay
@@ -34,12 +32,7 @@ class RecommendSchoolBottomSheet :
     }
 
     private fun setItemImage() {
-        binding.ivRecommendFriendThumbnail.apply {
-            val thumbnail = viewModel.clickedUserData.profileImageUrl
-            load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
-                transformations(CircleCropTransformation())
-            }
-        }
+        binding.ivRecommendFriendThumbnail.setImageOrBasicThumbnail(viewModel.clickedUserData.profileImageUrl)
     }
 
     private fun initAddBtnListener() {

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolFragment.kt
@@ -270,8 +270,8 @@ class RecommendSchoolFragment :
 
     private fun changeToCheckIcon(holder: RecommendViewHolder) {
         with(holder.binding) {
-            btnRecommendItemAdd.isVisible = false
-            btnRecommendItemAddPressed.isVisible = true
+            btnRecommendItemAdd.visibility = View.INVISIBLE
+            btnRecommendItemAddPressed.visibility = View.VISIBLE
         }
     }
 

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolFragment.kt
@@ -21,7 +21,6 @@ import com.el.yello.presentation.util.BaseLinearRcvItemDeco
 import com.el.yello.util.Utils.setPullToScrollColor
 import com.el.yello.util.amplitude.AmplitudeUtils
 import com.el.yello.util.context.yelloSnackbar
-import com.example.domain.entity.RecommendListModel
 import com.example.domain.entity.RecommendListModel.RecommendFriend
 import com.example.ui.base.BindingFragment
 import com.example.ui.view.UiState
@@ -45,7 +44,9 @@ class RecommendSchoolFragment :
 
     private var inviteYesFriendDialog: InviteFriendDialog? = null
     private var inviteNoFriendDialog: InviteFriendDialog? = null
-    private var lastClickedRecommendModel: RecommendListModel.RecommendFriend? = null
+    private var lastClickedRecommendModel: RecommendFriend? = null
+
+    private var recommendSchoolBottomSheet: RecommendSchoolBottomSheet? = null
 
     private lateinit var friendsList: List<RecommendFriend>
 
@@ -165,87 +166,80 @@ class RecommendSchoolFragment :
 
     // 추천친구 리스트 추가 서버 통신 성공 시 어댑터에 리스트 추가
     private fun observeAddListState() {
-        viewModel.postFriendsListState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
-            .onEach { state ->
-                when (state) {
-                    is UiState.Success -> {
-                        startFadeIn()
-                        if (state.data.friends.isEmpty() && adapter.itemCount == 0) {
-                            showNoFriendScreen()
-                        } else {
-                            showFriendListScreen()
-                            friendsList = state.data.friends
-                            adapter.addItemList(friendsList)
-                        }
+        viewModel.postFriendsListState.flowWithLifecycle(lifecycle).onEach { state ->
+            when (state) {
+                is UiState.Success -> {
+                    startFadeIn()
+                    if (state.data.friends.isEmpty() && adapter.itemCount == 0) {
+                        showShimmerView(isLoading = false, hasList = false)
+                    } else {
+                        showShimmerView(isLoading = false, hasList = true)
+                        friendsList = state.data.friends
+                        adapter.addItemList(friendsList)
                     }
-
-                    is UiState.Failure -> {
-                        showShimmerScreen()
-                        yelloSnackbar(
-                            requireView(),
-                            getString(R.string.recommend_error_school_friend_connection),
-                        )
-                    }
-
-                    is UiState.Loading -> showShimmerScreen()
-
-                    is UiState.Empty -> return@onEach
                 }
-            }.launchIn(viewLifecycleOwner.lifecycleScope)
+
+                is UiState.Failure -> {
+                    showShimmerView(isLoading = true, hasList = true)
+                    yelloSnackbar(
+                        requireView(),
+                        getString(R.string.recommend_error_school_friend_connection),
+                    )
+                }
+
+                is UiState.Loading -> showShimmerView(isLoading = true, hasList = true)
+
+                is UiState.Empty -> return@onEach
+            }
+        }.launchIn(lifecycleScope)
     }
 
     // 친구 추가 서버 통신 성공 시 리스트에서 아이템 삭제 & 서버 통신 중 액티비티 클릭 방지
     private fun observeAddFriendState() {
-        viewModel.addFriendState.flowWithLifecycle(viewLifecycleOwner.lifecycle)
-            .onEach { state ->
-                when (state) {
-                    is UiState.Success -> {
-                        val position = viewModel.itemPosition
-                        val holder = viewModel.itemHolder
-                        if (position != null && holder != null) {
-                            removeItemWithAnimation(holder, position)
-                        } else {
-                            activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
-                        }
-                    }
-
-                    is UiState.Failure -> {
-                        yelloSnackbar(
-                            requireView(),
-                            getString(R.string.recommend_error_add_friend_connection),
-                        )
+        viewModel.addFriendState.flowWithLifecycle(lifecycle).onEach { state ->
+            when (state) {
+                is UiState.Success -> {
+                    val position = viewModel.itemPosition
+                    val holder = viewModel.itemHolder
+                    if (position != null && holder != null) {
+                        removeItemWithAnimation(holder, position)
+                    } else {
                         activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
                     }
-
-                    is UiState.Loading -> {
-                        activity?.window?.setFlags(
-                            WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
-                            WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
-                        )
-                    }
-
-                    is UiState.Empty -> return@onEach
                 }
-            }.launchIn(viewLifecycleOwner.lifecycleScope)
+
+                is UiState.Failure -> {
+                    yelloSnackbar(
+                        requireView(),
+                        getString(R.string.recommend_error_add_friend_connection),
+                    )
+                    activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
+                }
+
+                is UiState.Loading -> {
+                    activity?.window?.setFlags(
+                        WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+                        WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+                    )
+                }
+
+                is UiState.Empty -> return@onEach
+            }
+        }.launchIn(lifecycleScope)
     }
 
     private fun observeUserDataState() {
-        viewModel.getUserDataState.flowWithLifecycle(viewLifecycleOwner.lifecycle).onEach { state ->
-            when (state) {
-                is UiState.Success -> {
-                    viewModel.clickedUserData = state.data.apply {
-                        if (!this.yelloId.startsWith("@")) this.yelloId = "@" + this.yelloId
-                    }
-                    if (lastClickedRecommendModel != null) {
-                        RecommendSchoolBottomSheet().show(
-                            parentFragmentManager,
-                            ITEM_BOTTOM_SHEET,
-                        )
-                    }
+        viewModel.getUserDataState.flowWithLifecycle(lifecycle).onEach { state ->
+            if (state is UiState.Success) {
+                viewModel.clickedUserData = state.data.apply {
+                    if (!this.yelloId.startsWith("@")) this.yelloId = "@" + this.yelloId
                 }
-                else -> {}
+                if (lastClickedRecommendModel != null) {
+                    recommendSchoolBottomSheet = RecommendSchoolBottomSheet()
+                    recommendSchoolBottomSheet?.show(parentFragmentManager, ITEM_BOTTOM_SHEET)
+                }
             }
-        }.launchIn(viewLifecycleOwner.lifecycleScope)
+        }.launchIn(lifecycleScope)
     }
 
     private fun setDeleteAnimation() {
@@ -256,11 +250,6 @@ class RecommendSchoolFragment :
                 return super.animateRemove(holder)
             }
         }
-    }
-
-    private fun dismissDialog() {
-        if (inviteYesFriendDialog?.isAdded == true) inviteYesFriendDialog?.dismiss()
-        if (inviteNoFriendDialog?.isAdded == true) inviteNoFriendDialog?.dismiss()
     }
 
     // 삭제 시 체크 버튼으로 전환 후 0.3초 뒤 애니메이션 적용
@@ -274,15 +263,15 @@ class RecommendSchoolFragment :
             activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
             binding.rvRecommendSchool.addItemDecoration(itemDivider)
             if (adapter.itemCount == 0) {
-                showNoFriendScreen()
+                showShimmerView(isLoading = false, hasList = false)
             }
         }
     }
 
     private fun changeToCheckIcon(holder: RecommendViewHolder) {
         with(holder.binding) {
-            btnRecommendItemAdd.visibility = View.INVISIBLE
-            btnRecommendItemAddPressed.visibility = View.VISIBLE
+            btnRecommendItemAdd.isVisible = false
+            btnRecommendItemAddPressed.isVisible = true
         }
     }
 
@@ -291,31 +280,13 @@ class RecommendSchoolFragment :
         binding.rvRecommendSchool.startAnimation(animation)
     }
 
-    private fun showShimmerScreen() {
+    private fun showShimmerView(isLoading: Boolean, hasList: Boolean) {
         with(binding) {
-            layoutRecommendFriendsList.isVisible = true
-            layoutRecommendNoFriendsList.isVisible = false
-            shimmerFriendList.startShimmer()
-            shimmerFriendList.isVisible = true
-            rvRecommendSchool.isVisible = false
-        }
-    }
-
-    private fun showFriendListScreen() {
-        with(binding) {
-            layoutRecommendFriendsList.isVisible = true
-            layoutRecommendNoFriendsList.isVisible = false
-            shimmerFriendList.startShimmer()
-            shimmerFriendList.isVisible = false
-            rvRecommendSchool.isVisible = true
-        }
-    }
-
-    private fun showNoFriendScreen() {
-        with(binding) {
-            layoutRecommendFriendsList.isVisible = false
-            layoutRecommendNoFriendsList.isVisible = true
-            shimmerFriendList.stopShimmer()
+            if (isLoading) shimmerFriendList.startShimmer() else shimmerFriendList.stopShimmer()
+            layoutRecommendFriendsList.isVisible = hasList
+            layoutRecommendNoFriendsList.isVisible = !hasList
+            shimmerFriendList.isVisible = isLoading
+            rvRecommendSchool.isVisible = !isLoading
         }
     }
 
@@ -326,7 +297,9 @@ class RecommendSchoolFragment :
     override fun onDestroyView() {
         super.onDestroyView()
         _adapter = null
-        dismissDialog()
+        if (inviteYesFriendDialog?.isAdded == true) inviteYesFriendDialog?.dismiss()
+        if (inviteNoFriendDialog?.isAdded == true) inviteNoFriendDialog?.dismiss()
+        if (recommendSchoolBottomSheet != null) recommendSchoolBottomSheet?.dismiss()
     }
 
     private companion object {

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolFragment.kt
@@ -62,7 +62,7 @@ class RecommendSchoolFragment :
         setItemDecoration()
         setAdapterWithClickListener()
         setListWithInfinityScroll()
-        observeAddListState()
+        observeAddFriendsListState()
         observeAddFriendState()
         observeUserDataState()
         setDeleteAnimation()
@@ -74,7 +74,7 @@ class RecommendSchoolFragment :
         if (viewModel.isSearchViewShowed) {
             adapter.clearList()
             viewModel.setFirstPageLoading()
-            viewModel.addListGroupFromServer()
+            viewModel.getSchoolFriendsListFromServer()
             viewModel.isSearchViewShowed = false
         }
     }
@@ -108,7 +108,7 @@ class RecommendSchoolFragment :
 
     private fun initFirstList() {
         viewModel.setFirstPageLoading()
-        viewModel.addListGroupFromServer()
+        viewModel.getSchoolFriendsListFromServer()
     }
 
     private fun initPullToScrollListener() {
@@ -117,7 +117,7 @@ class RecommendSchoolFragment :
                 lifecycleScope.launch {
                     adapter.clearList()
                     viewModel.setFirstPageLoading()
-                    viewModel.addListGroupFromServer()
+                    viewModel.getSchoolFriendsListFromServer()
                     delay(200)
                     binding.layoutRecommendSchoolSwipe.isRefreshing = false
                 }
@@ -132,7 +132,6 @@ class RecommendSchoolFragment :
         binding.rvRecommendSchool.addItemDecoration(BaseLinearRcvItemDeco(bottomPadding = 12))
     }
 
-    // 처음 리스트 설정 및 어댑터 클릭 리스너 설정
     private fun setAdapterWithClickListener() {
         _adapter = RecommendAdapter(
             buttonClick = { recommendModel, position, holder ->
@@ -148,7 +147,6 @@ class RecommendSchoolFragment :
         binding.rvRecommendSchool.adapter = adapter
     }
 
-    // 무한 스크롤 구현
     private fun setListWithInfinityScroll() {
         binding.rvRecommendSchool.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
@@ -156,7 +154,7 @@ class RecommendSchoolFragment :
                 if (dy > 0) {
                     recyclerView.layoutManager?.let { layoutManager ->
                         if (!binding.rvRecommendSchool.canScrollVertically(1) && layoutManager is LinearLayoutManager && layoutManager.findLastVisibleItemPosition() == adapter.itemCount - 1) {
-                            viewModel.addListGroupFromServer()
+                            viewModel.getSchoolFriendsListFromServer()
                         }
                     }
                 }
@@ -164,8 +162,7 @@ class RecommendSchoolFragment :
         })
     }
 
-    // 추천친구 리스트 추가 서버 통신 성공 시 어댑터에 리스트 추가
-    private fun observeAddListState() {
+    private fun observeAddFriendsListState() {
         viewModel.postFriendsListState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
                 is UiState.Success -> {
@@ -194,7 +191,6 @@ class RecommendSchoolFragment :
         }.launchIn(lifecycleScope)
     }
 
-    // 친구 추가 서버 통신 성공 시 리스트에서 아이템 삭제 & 서버 통신 중 액티비티 클릭 방지
     private fun observeAddFriendState() {
         viewModel.addFriendState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
@@ -252,7 +248,6 @@ class RecommendSchoolFragment :
         }
     }
 
-    // 삭제 시 체크 버튼으로 전환 후 0.3초 뒤 애니메이션 적용
     private fun removeItemWithAnimation(holder: RecommendViewHolder, position: Int) {
         lifecycleScope.launch {
             changeToCheckIcon(holder)

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.el.yello.presentation.main.recommend.list.RecommendViewHolder
 import com.example.domain.entity.RecommendListModel
 import com.example.domain.entity.RecommendUserInfoModel
+import com.example.domain.entity.setEmptyRecommendUserInfoModel
 import com.example.domain.repository.AuthRepository
 import com.example.domain.repository.RecommendRepository
 import com.example.ui.view.UiState
@@ -36,8 +37,7 @@ class RecommendSchoolViewModel @Inject constructor(
     var itemPosition: Int? = null
     var itemHolder: RecommendViewHolder? = null
 
-    var isItemBottomSheetRunning: Boolean = false
-    var clickedUserData = RecommendUserInfoModel(0, "", "", "", "", 0, 0)
+    var clickedUserData = setEmptyRecommendUserInfoModel()
 
     private var currentPage = -1
     private var isPagingFinish = false

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolViewModel.kt
@@ -58,8 +58,7 @@ class RecommendSchoolViewModel @Inject constructor(
         itemHolder = holder
     }
 
-    // 서버 통신 - 추천 친구 리스트 추가
-    fun addListGroupFromServer() {
+    fun getSchoolFriendsListFromServer() {
         viewModelScope.launch {
             if (isPagingFinish) return@launch
             if (isFirstFriendsListPage) {
@@ -81,7 +80,6 @@ class RecommendSchoolViewModel @Inject constructor(
         }
     }
 
-    // 서버 통신 - 친구 추가
     fun addFriendToServer(friendId: Long) {
         viewModelScope.launch {
             _addFriendState.value = UiState.Loading
@@ -95,7 +93,6 @@ class RecommendSchoolViewModel @Inject constructor(
         }
     }
 
-    // 서버 통신 - 특정 유저 받아오기
     fun getUserDataFromServer(userId: Long) {
         viewModelScope.launch {
             _getUserDataState.value = UiState.Loading

--- a/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/recommend/school/RecommendSchoolViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.el.yello.presentation.main.recommend.list.RecommendViewHolder
 import com.example.domain.entity.RecommendListModel
 import com.example.domain.entity.RecommendUserInfoModel
-import com.example.domain.entity.setEmptyRecommendUserInfoModel
 import com.example.domain.repository.AuthRepository
 import com.example.domain.repository.RecommendRepository
 import com.example.ui.view.UiState
@@ -37,7 +36,7 @@ class RecommendSchoolViewModel @Inject constructor(
     var itemPosition: Int? = null
     var itemHolder: RecommendViewHolder? = null
 
-    var clickedUserData = setEmptyRecommendUserInfoModel()
+    var clickedUserData = RecommendUserInfoModel()
 
     private var currentPage = -1
     private var isPagingFinish = false

--- a/app/src/main/java/com/el/yello/presentation/pay/PayActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/pay/PayActivity.kt
@@ -59,8 +59,8 @@ class PayActivity : BindingActivity<ActivityPayBinding>(R.layout.activity_pay) {
         setBillingManager()
         observeIsPurchasing()
         observePurchaseInfoState()
-        observeCheckSubsState()
-        observeCheckInAppState()
+        observeCheckSubsValidState()
+        observeCheckInAppValidState()
         initPrivacyBtnListener()
         initServiceBtnListener()
     }
@@ -104,9 +104,9 @@ class PayActivity : BindingActivity<ActivityPayBinding>(R.layout.activity_pay) {
 
                 override fun onSuccess(purchase: Purchase) {
                     if (purchase.products[0] == YELLO_PLUS) {
-                        viewModel.checkSubsToServer(purchase.toRequestPayModel())
+                        viewModel.checkSubsValidToServer(purchase.toRequestPayModel())
                     } else {
-                        viewModel.checkInAppToServer(purchase.toRequestPayModel())
+                        viewModel.checkInAppValidToServer(purchase.toRequestPayModel())
                     }
                 }
 
@@ -162,14 +162,12 @@ class PayActivity : BindingActivity<ActivityPayBinding>(R.layout.activity_pay) {
         })
     }
 
-    // 구매 완료 이후 검증 완료까지 로딩 로티 실행
     private fun observeIsPurchasing() {
         manager.isPurchasing.flowWithLifecycle(lifecycle).onEach { isPurchasing ->
             if (isPurchasing) startLoadingScreen()
         }.launchIn(lifecycleScope)
     }
 
-    // 구독 여부 확인해서 화면 표시 변경
     private fun observePurchaseInfoState() {
         viewModel.getPurchaseInfoState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
@@ -189,8 +187,7 @@ class PayActivity : BindingActivity<ActivityPayBinding>(R.layout.activity_pay) {
         }.launchIn(lifecycleScope)
     }
 
-    // 구독 상품 검증 옵저버
-    private fun observeCheckSubsState() {
+    private fun observeCheckSubsValidState() {
         viewModel.postSubsCheckState.flowWithLifecycle(lifecycle).onEach { state ->
             stopLoadingScreen()
             when (state) {
@@ -217,8 +214,7 @@ class PayActivity : BindingActivity<ActivityPayBinding>(R.layout.activity_pay) {
         }.launchIn(lifecycleScope)
     }
 
-    // 인앱(소비성) 상품 검증 옵저버
-    private fun observeCheckInAppState() {
+    private fun observeCheckInAppValidState() {
         viewModel.postInAppCheckState.flowWithLifecycle(lifecycle).onEach { state ->
             when (state) {
                 is UiState.Success -> {

--- a/app/src/main/java/com/el/yello/presentation/pay/PayViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/pay/PayViewModel.kt
@@ -45,8 +45,7 @@ class PayViewModel @Inject constructor(
         ticketCount += count
     }
 
-    // 서버 통신 - 구독 상품 검증
-    fun checkSubsToServer(request: PayRequestModel) {
+    fun checkSubsValidToServer(request: PayRequestModel) {
         viewModelScope.launch {
             _postSubsCheckState.value = UiState.Loading
             payRepository.postToCheckSubs(request)
@@ -59,8 +58,7 @@ class PayViewModel @Inject constructor(
         }
     }
 
-    // 서버 통신 - 열람권 상품 검증
-    fun checkInAppToServer(request: PayRequestModel) {
+    fun checkInAppValidToServer(request: PayRequestModel) {
         viewModelScope.launch {
             _postInAppCheckState.value = UiState.Loading
             payRepository.postToCheckInApp(request)
@@ -87,7 +85,6 @@ class PayViewModel @Inject constructor(
         }
     }
 
-    // 서버 통신 - 구독 여부 & 열람권 개수 받아오기
     fun getPurchaseInfoFromServer() {
         viewModelScope.launch {
             payRepository.getPurchaseInfo()

--- a/app/src/main/java/com/el/yello/presentation/search/SearchViewHolder.kt
+++ b/app/src/main/java/com/el/yello/presentation/search/SearchViewHolder.kt
@@ -7,6 +7,7 @@ import coil.transform.CircleCropTransformation
 import com.el.yello.R
 import com.el.yello.databinding.ItemRecommendSearchBinding
 import com.el.yello.presentation.main.profile.ProfileViewModel
+import com.el.yello.util.Utils.setImageOrBasicThumbnail
 import com.example.domain.entity.SearchListModel.SearchFriendModel
 import com.example.ui.view.setOnSingleClickListener
 
@@ -21,15 +22,7 @@ class SearchViewHolder(
         binding.tvRecommendItemId.text = String.format("@%s", item.yelloId)
         binding.tvRecommendItemSchool.text = item.group
 
-        item.profileImage.let { thumbnail ->
-            if (thumbnail == ProfileViewModel.BASIC_THUMBNAIL) {
-                binding.ivRecommendItemThumbnail.load(R.drawable.img_yello_basic)
-            } else {
-                binding.ivRecommendItemThumbnail.load(thumbnail) {
-                    transformations(CircleCropTransformation())
-                }
-            }
-        }
+        binding.ivRecommendItemThumbnail.setImageOrBasicThumbnail(item.profileImage)
 
         if (item.isFriend) {
             binding.btnRecommendItemAdd.visibility = View.GONE

--- a/app/src/main/java/com/el/yello/presentation/search/SearchViewHolder.kt
+++ b/app/src/main/java/com/el/yello/presentation/search/SearchViewHolder.kt
@@ -1,12 +1,8 @@
 package com.el.yello.presentation.search
 
-import android.view.View
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
-import coil.load
-import coil.transform.CircleCropTransformation
-import com.el.yello.R
 import com.el.yello.databinding.ItemRecommendSearchBinding
-import com.el.yello.presentation.main.profile.ProfileViewModel
 import com.el.yello.util.Utils.setImageOrBasicThumbnail
 import com.example.domain.entity.SearchListModel.SearchFriendModel
 import com.example.ui.view.setOnSingleClickListener
@@ -14,26 +10,22 @@ import com.example.ui.view.setOnSingleClickListener
 class SearchViewHolder(
     val binding: ItemRecommendSearchBinding,
     private val itemClick: (SearchFriendModel, Int, SearchViewHolder) -> Unit,
-) :
-    RecyclerView.ViewHolder(binding.root) {
+) : RecyclerView.ViewHolder(binding.root) {
 
     fun onBind(item: SearchFriendModel, position: Int) {
-        binding.tvRecommendItemName.text = item.name
-        binding.tvRecommendItemId.text = String.format("@%s", item.yelloId)
-        binding.tvRecommendItemSchool.text = item.group
+        with(binding) {
+            tvRecommendItemName.text = item.name
+            tvRecommendItemId.text = String.format("@%s", item.yelloId)
+            tvRecommendItemSchool.text = item.group
 
-        binding.ivRecommendItemThumbnail.setImageOrBasicThumbnail(item.profileImage)
+            ivRecommendItemThumbnail.setImageOrBasicThumbnail(item.profileImage)
 
-        if (item.isFriend) {
-            binding.btnRecommendItemAdd.visibility = View.GONE
-            binding.btnRecommendItemMyFriend.visibility = View.VISIBLE
-        } else {
-            binding.btnRecommendItemAdd.visibility = View.VISIBLE
-            binding.btnRecommendItemMyFriend.visibility = View.GONE
-        }
+            btnRecommendItemAdd.isVisible = !item.isFriend
+            btnRecommendItemMyFriend.isVisible = item.isFriend
 
-        binding.btnRecommendItemAdd.setOnSingleClickListener {
-            itemClick(item, position, this)
+            btnRecommendItemAdd.setOnSingleClickListener {
+                itemClick(item, position, this@SearchViewHolder)
+            }
         }
     }
 }

--- a/app/src/main/java/com/el/yello/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/el/yello/presentation/search/SearchViewModel.kt
@@ -47,8 +47,7 @@ class SearchViewModel @Inject constructor(
         _postFriendsListState.value = UiState.Empty
     }
 
-    // 서버 통신 - 추천 친구 리스트 추가
-    fun setListFromServer(keyword: String) {
+    fun setFriendsListFromServer(keyword: String) {
         if (isPagingFinish) return
         viewModelScope.launch {
             searchRepository.getSearchList(
@@ -67,7 +66,6 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    // 서버 통신 - 친구 추가
     fun addFriendToServer(friendId: Long) {
         _addFriendState.value = UiState.Loading
         viewModelScope.launch {

--- a/app/src/main/java/com/el/yello/util/Utils.kt
+++ b/app/src/main/java/com/el/yello/util/Utils.kt
@@ -1,7 +1,11 @@
 package com.el.yello.util
 
+import android.widget.ImageView
 import androidx.core.content.ContextCompat
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import coil.load
+import coil.transform.CircleCropTransformation
+import com.el.yello.R
 
 object Utils {
     fun setChosungText(name: String, number: Int): String {
@@ -23,5 +27,16 @@ object Utils {
         setColorSchemeColors(ContextCompat.getColor(context, arrowColor))
         setProgressBackgroundColorSchemeColor(ContextCompat.getColor(context, bgColor))
     }
+
+    fun ImageView.setImageOrBasicThumbnail(thumbnail: String) {
+        this.apply {
+            load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
+                transformations(CircleCropTransformation())
+            }
+        }
+    }
+
+    const val BASIC_THUMBNAIL =
+        "https://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg"
 
 }

--- a/app/src/main/java/com/el/yello/util/Utils.kt
+++ b/app/src/main/java/com/el/yello/util/Utils.kt
@@ -1,11 +1,11 @@
 package com.el.yello.util
 
 import android.widget.ImageView
-import androidx.core.content.ContextCompat
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import coil.load
 import coil.transform.CircleCropTransformation
 import com.el.yello.R
+import com.example.ui.context.colorOf
 
 object Utils {
     fun setChosungText(name: String, number: Int): String {
@@ -24,19 +24,19 @@ object Utils {
     }
 
     fun SwipeRefreshLayout.setPullToScrollColor(arrowColor: Int, bgColor: Int) {
-        setColorSchemeColors(ContextCompat.getColor(context, arrowColor))
-        setProgressBackgroundColorSchemeColor(ContextCompat.getColor(context, bgColor))
+        setColorSchemeColors(context.colorOf(arrowColor))
+        setProgressBackgroundColorSchemeColor(context.colorOf(bgColor))
     }
 
     fun ImageView.setImageOrBasicThumbnail(thumbnail: String) {
         this.apply {
-            load(if (thumbnail == BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
+            load(if (thumbnail == URL_BASIC_THUMBNAIL) R.drawable.img_yello_basic else thumbnail) {
                 transformations(CircleCropTransformation())
             }
         }
     }
 
-    const val BASIC_THUMBNAIL =
+    private const val URL_BASIC_THUMBNAIL =
         "https://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg"
 
 }

--- a/app/src/main/res/drawable/ic_warning_mini.xml
+++ b/app/src/main/res/drawable/ic_warning_mini.xml
@@ -1,0 +1,25 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="12dp"
+    android:viewportWidth="12"
+    android:viewportHeight="12">
+    <group>
+        <clip-path
+            android:pathData="M0,0h12v12h-12z"/>
+        <path
+            android:strokeWidth="1"
+            android:pathData="M6,11C8.761,11 11,8.761 11,6C11,3.239 8.761,1 6,1C3.239,1 1,3.239 1,6C1,8.761 3.239,11 6,11Z"
+            android:strokeLineJoin="round"
+            android:fillColor="#00000000"
+            android:strokeColor="#9093A8"
+            android:strokeLineCap="round"/>
+        <path
+            android:pathData="M6,3.5C6.276,3.5 6.5,3.724 6.5,4V6C6.5,6.276 6.276,6.5 6,6.5C5.724,6.5 5.5,6.276 5.5,6V4C5.5,3.724 5.724,3.5 6,3.5Z"
+            android:fillColor="#9093A8"
+            android:fillType="evenOdd"/>
+        <path
+            android:pathData="M5.5,8C5.5,7.724 5.726,7.5 6.002,7.5C6.279,7.5 6.505,7.724 6.505,8C6.505,8.276 6.279,8.5 6.002,8.5C5.726,8.5 5.5,8.276 5.5,8Z"
+            android:fillColor="#9093A8"
+            android:fillType="evenOdd"/>
+    </group>
+</vector>

--- a/app/src/main/res/layout/activity_social_sync.xml
+++ b/app/src/main/res/layout/activity_social_sync.xml
@@ -92,5 +92,36 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <LinearLayout
+            android:id="@+id/btn_social_sync_terms"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:orientation="horizontal"
+            android:padding="12dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btn_social_sync">
+
+            <ImageView
+                android:id="@+id/tv_social_sync_terms_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:layout_marginEnd="2dp"
+                android:src="@drawable/ic_warning_mini" />
+
+            <TextView
+                android:id="@+id/tv_social_sync_terms_text"
+                style="@style/TextAppearance.Yello.LabelLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/social_sync_tv_info"
+                android:textColor="@color/grayscales_500" />
+
+        </LinearLayout>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
+
 </layout>

--- a/app/src/main/res/values/appearances.xml
+++ b/app/src/main/res/values/appearances.xml
@@ -6,102 +6,103 @@
         <item name="android:textColor">@color/black</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:includeFontPadding">false</item>
+        <item name="android:lineSpacingMultiplier">1.2</item>
     </style>
 
+    <!-- paddingVertical 3dp -->
     <style name="TextAppearance.Yello.Headline00">
         <item name="fontFamily">@font/font_pretendard_bold</item>
         <item name="android:textSize">26sp</item>
-        <item name="lineHeight">32sp</item>
     </style>
 
+    <!-- paddingVertical 5dp -->
     <style name="TextAppearance.Yello.Headline01">
         <item name="fontFamily">@font/font_pretendard_bold</item>
         <item name="android:textSize">22sp</item>
-        <item name="lineHeight">32sp</item>
     </style>
 
+    <!-- paddingVertical 5dp -->
     <style name="TextAppearance.Yello.Headline02">
         <item name="fontFamily">@font/font_pretendard_bold</item>
         <item name="android:textSize">22sp</item>
-        <item name="lineHeight">32sp</item>
     </style>
 
+    <!-- paddingVertical 5dp -->
     <style name="TextAppearance.Yello.Headline03">
         <item name="fontFamily">@font/font_pretendard_bold</item>
         <item name="android:textSize">21sp</item>
-        <item name="lineHeight">30sp</item>
     </style>
 
+    <!-- paddingVertical 3dp -->
     <style name="TextAppearance.Yello.Subtitle01">
         <item name="fontFamily">@font/font_pretendard_semibold</item>
         <item name="android:textSize">18sp</item>
-        <item name="lineHeight">24sp</item>
     </style>
 
+    <!-- paddingVertical 3dp -->
     <style name="TextAppearance.Yello.Subtitle02">
         <item name="fontFamily">@font/font_pretendard_bold</item>
         <item name="android:textSize">16sp</item>
-        <item name="lineHeight">22sp</item>
     </style>
 
+    <!-- paddingVertical 5dp -->
     <style name="TextAppearance.Yello.BodyLarge">
         <item name="fontFamily">@font/font_pretendard_medium</item>
         <item name="android:textSize">16sp</item>
-        <item name="lineHeight">26sp</item>
     </style>
 
+    <!-- paddingVertical 5dp -->
     <style name="TextAppearance.Yello.BodyMedium">
         <item name="fontFamily">@font/font_pretendard_medium</item>
         <item name="android:textSize">15sp</item>
-        <item name="lineHeight">24sp</item>
     </style>
 
+    <!-- paddingVertical 4dp -->
     <style name="TextAppearance.Yello.BodySmall">
         <item name="fontFamily">@font/font_pretendard_medium</item>
         <item name="android:textSize">14sp</item>
-        <item name="lineHeight">22sp</item>
     </style>
 
+    <!-- paddingVertical 5dp -->
     <style name="TextAppearance.Yello.Body02">
         <item name="fontFamily">@font/font_pretendard_regular</item>
         <item name="android:textSize">13sp</item>
-        <item name="lineHeight">22sp</item>
     </style>
 
+    <!-- paddingVertical 2dp -->
     <style name="TextAppearance.Yello.LabelLarge">
         <item name="fontFamily">@font/font_pretendard_medium</item>
         <item name="android:textSize">12sp</item>
-        <item name="lineHeight">16sp</item>
     </style>
 
+    <!-- paddingVertical 2dp -->
     <style name="TextAppearance.Yello.LabelMedium">
         <item name="fontFamily">@font/font_pretendard_medium</item>
         <item name="android:textSize">11sp</item>
-        <item name="lineHeight">15sp</item>
     </style>
 
+    <!-- paddingVertical 2dp -->
     <style name="TextAppearance.Yello.LabelSmall">
         <item name="fontFamily">@font/font_pretendard_medium</item>
         <item name="android:textSize">10sp</item>
-        <item name="lineHeight">14sp</item>
     </style>
 
+    <!-- paddingVertical 5dp -->
     <style name="TextAppearance.Yello.Body01">
         <item name="fontFamily">@font/font_pretendard_medium</item>
         <item name="android:textSize">15sp</item>
-        <item name="lineHeight">24sp</item>
     </style>
 
+    <!-- paddingVertical 3dp -->
     <style name="TextAppearance.Yello.Button">
         <item name="fontFamily">@font/font_pretendard_semibold</item>
         <item name="android:textSize">13sp</item>
-        <item name="lineHeight">18sp</item>
     </style>
 
+    <!-- paddingVertical 4dp -->
     <style name="TextAppearance.Yello.Dialog">
         <item name="fontFamily">@font/font_pretendard_medium</item>
         <item name="android:textSize">13sp</item>
-        <item name="lineHeight">20sp</item>
     </style>
 
     <!-- Bottom Navigation View Custom TextAppearances. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,7 +26,7 @@
     <string name="social_sync_tv_title">나의 옐로 친구는 어디 있을까?</string>
     <string name="social_sync_tv_subtitle">친구 목록을 불러와봐요!</string>
     <string name="social_sync_tv_btn">카카오톡 친구 연결하기</string>
-    <string name="social_sync_tv_info"><u>개인정보처리약관</u></string>
+    <string name="social_sync_tv_info"><u>개인정보처리방침</u></string>
     <string name="social_sync_error_kakao_profile">카카오 프로필 가져오기 실패</string>
 
     <string name="main_recommend">추천친구</string>

--- a/core-ui/src/main/java/com/example/ui/base/BindingActivity.kt
+++ b/core-ui/src/main/java/com/example/ui/base/BindingActivity.kt
@@ -1,5 +1,6 @@
 package com.example.ui.base
 
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.MotionEvent
 import android.view.View
@@ -12,6 +13,7 @@ import com.example.ui.context.hideKeyboard
 abstract class BindingActivity<T : ViewDataBinding>(
     @LayoutRes private val layoutResId: Int,
 ) : AppCompatActivity() {
+
     protected lateinit var binding: T
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -21,7 +23,18 @@ abstract class BindingActivity<T : ViewDataBinding>(
     }
 
     override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
-        hideKeyboard(currentFocus ?: View(this))
+        if (ev?.action == MotionEvent.ACTION_UP){
+            val currentFocus = currentFocus
+            if (currentFocus != null && isTouchOutsideView(currentFocus, ev)){
+                hideKeyboard(currentFocus)
+                currentFocus.clearFocus()
+            }
+        }
         return super.dispatchTouchEvent(ev)
+    }
+
+    private fun isTouchOutsideView(view: View, ev: MotionEvent): Boolean {
+        val outRect = Rect(view.left, view.top, view.right, view.bottom)
+        return !outRect.contains(ev.rawX.toInt(), ev.rawY.toInt())
     }
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -11,6 +11,4 @@ java {
 
 dependencies {
     implementation(libs.bundles.kotlin)
-    implementation(libs.hiltCore)
-    kapt(libs.hiltAndroidCompiler)
 }

--- a/domain/src/main/java/com/example/domain/entity/ProfileUserModel.kt
+++ b/domain/src/main/java/com/example/domain/entity/ProfileUserModel.kt
@@ -10,3 +10,6 @@ data class ProfileUserModel(
     val friendCount: Int,
     val point: Int
 )
+
+fun getEmptyProfileUserModel() =
+    ProfileUserModel(0, "", "", "", "", 0, 0, 0)

--- a/domain/src/main/java/com/example/domain/entity/ProfileUserModel.kt
+++ b/domain/src/main/java/com/example/domain/entity/ProfileUserModel.kt
@@ -9,7 +9,6 @@ data class ProfileUserModel(
     val yelloCount: Int,
     val friendCount: Int,
     val point: Int
-)
-
-fun getEmptyProfileUserModel() =
-    ProfileUserModel(0, "", "", "", "", 0, 0, 0)
+){
+    constructor() : this(0, "", "", "", "", 0, 0, 0)
+}

--- a/domain/src/main/java/com/example/domain/entity/RecommendUserInfoModel.kt
+++ b/domain/src/main/java/com/example/domain/entity/RecommendUserInfoModel.kt
@@ -8,7 +8,6 @@ data class RecommendUserInfoModel(
     var yelloId: String,
     val yelloCount: Int,
     val friendCount: Int,
-)
-
-fun setEmptyRecommendUserInfoModel() =
-    RecommendUserInfoModel(0, "", "", "", "", 0, 0)
+) {
+    constructor() : this(0, "", "", "", "", 0, 0)
+}

--- a/domain/src/main/java/com/example/domain/entity/RecommendUserInfoModel.kt
+++ b/domain/src/main/java/com/example/domain/entity/RecommendUserInfoModel.kt
@@ -9,3 +9,6 @@ data class RecommendUserInfoModel(
     val yelloCount: Int,
     val friendCount: Int,
 )
+
+fun setEmptyRecommendUserInfoModel() =
+    RecommendUserInfoModel(0, "", "", "", "", 0, 0)


### PR DESCRIPTION
- closed #349 
- closed #305 

## *⛳️ Work Description*
- OkhttpLogInterceptor 의 response data가 줄바꿈이 적용되도록 수정
- 까먹고 다시 안돌려뒀던 <카카오 친구권한받기 뷰>의 개인정보처리약관 버튼 다시 살림
- Binding Activity에서 뷰의 컴포넌트가 아닌 배경을 눌러야지만 hideKeyboard가 적용되도록 수정
- 뷰홀더들에서 직관적이게 스코프 함수 활용
- shimmer 관련 함수 boolean 값들을 활용해서 하나로 합침
- 옵저버들에 viewLifecycleOwner. 지워주기
- 카톡 기본 프로필인 경우 노란색 기본썸네일 표시해주는 기능을 확장함수로 따로 뺴줌
- domain gradle에서 hilt 제거 (코틀린만 들어가 있어야 하지 않나요?)
- SignIn, Profile 뷰에서 비즈니스 로직 뷰모델로 SharedFlow 활용해서 모아둠
- textAppearance 수정 : 적용안되던 lineHeight 대신 `android:lineSpacingMultiplier 1.2` 로 통일함 (위아래 padding 값으로 설정해두고 싶지만, 우리 기존에 모든 뷰에서 각자 paddingVertical 값들을 줘둬서 고치기 귀찮아서... 주석값으로 얼마 주면 되는지 표시해두었슴둥 참고해주세요)

## *📢 To Reviewers*
- 자세한 검토 부탁드리옵니다 우하하
