### PR TITLE
[FEAT/#419] 푸시 알림(FCM) 추가 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,13 +9,8 @@
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
     <uses-permission android:name="com.google.android.play.billingclient.version" />
     <uses-permission android:name="com.android.vending.BILLING" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
     <queries>
         <package android:name="com.instagram.android" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,6 @@
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
     <uses-permission android:name="com.google.android.play.billingclient.version" />
     <uses-permission android:name="com.android.vending.BILLING" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <queries>

--- a/app/src/main/java/com/el/yello/config/YelloMessagingService.kt
+++ b/app/src/main/java/com/el/yello/config/YelloMessagingService.kt
@@ -35,7 +35,7 @@ class YelloMessagingService : FirebaseMessagingService() {
             GlobalScope.launch {
                 runCatching {
                     authService.putDeviceToken(
-                        token.toDeviceToken()
+                        token.toDeviceToken(),
                     )
                 }.onFailure(Timber::e)
             }
@@ -66,7 +66,7 @@ class YelloMessagingService : FirebaseMessagingService() {
                 this,
                 notifyId,
                 intent,
-                PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_MUTABLE
+                PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_MUTABLE,
             )
 
         val channelId = getString(R.string.default_notification_channel_id)
@@ -82,7 +82,9 @@ class YelloMessagingService : FirebaseMessagingService() {
 
         val notificationManager = getSystemService<NotificationManager>()
         val channel = NotificationChannel(
-            channelId, channelId, NotificationManager.IMPORTANCE_HIGH
+            channelId,
+            channelId,
+            NotificationManager.IMPORTANCE_HIGH,
         )
 
         notificationManager?.run {
@@ -96,7 +98,7 @@ class YelloMessagingService : FirebaseMessagingService() {
         var body: String,
         var type: String,
         var path: String? = null,
-        var badge: Int? = null
+        var badge: Int? = null,
     )
 
     companion object {

--- a/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SignInActivity.kt
@@ -179,7 +179,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
             putExtra(EXTRA_EMAIL, viewModel.kakaoUserInfo.kakaoAccount?.email.orEmpty())
             putExtra(
                 EXTRA_PROFILE_IMAGE,
-                viewModel.kakaoUserInfo.kakaoAccount?.profile?.profileImageUrl.orEmpty()
+                viewModel.kakaoUserInfo.kakaoAccount?.profile?.profileImageUrl.orEmpty(),
             )
             addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         }
@@ -193,7 +193,7 @@ class SignInActivity : BindingActivity<ActivitySignInBinding>(R.layout.activity_
             putString(EXTRA_EMAIL, viewModel.kakaoUserInfo.kakaoAccount?.email.orEmpty())
             putString(
                 EXTRA_PROFILE_IMAGE,
-                viewModel.kakaoUserInfo.kakaoAccount?.profile?.profileImageUrl.orEmpty()
+                viewModel.kakaoUserInfo.kakaoAccount?.profile?.profileImageUrl.orEmpty(),
             )
         }
     }

--- a/app/src/main/java/com/el/yello/presentation/auth/SocialSyncActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/auth/SocialSyncActivity.kt
@@ -15,14 +15,14 @@ import com.el.yello.presentation.auth.SignInActivity.Companion.EXTRA_GENDER
 import com.el.yello.presentation.auth.SignInActivity.Companion.EXTRA_KAKAO_ID
 import com.el.yello.presentation.auth.SignInActivity.Companion.EXTRA_NAME
 import com.el.yello.presentation.auth.SignInActivity.Companion.EXTRA_PROFILE_IMAGE
-import com.el.yello.presentation.setting.SettingActivity.Companion.PRIVACY_URL
 import com.el.yello.presentation.onboarding.activity.EditNameActivity
 import com.el.yello.presentation.onboarding.fragment.checkName.CheckNameDialog
-import com.el.yello.util.manager.AmplitudeManager
+import com.el.yello.presentation.setting.SettingActivity.Companion.PRIVACY_URL
 import com.el.yello.util.extension.yelloSnackbar
+import com.el.yello.util.manager.AmplitudeManager
 import com.example.ui.base.BindingActivity
-import com.example.ui.state.UiState
 import com.example.ui.extension.setOnSingleClickListener
+import com.example.ui.state.UiState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach

--- a/app/src/main/java/com/el/yello/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/MainActivity.kt
@@ -188,11 +188,10 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
             }
             PUSH_TYPE_OPEN_VOTE -> {
                 binding.bnvMain.menu.getItem(1).isChecked = true
-                // TODO: 내가 보낸 쪽지 필터링 이동하는지 확인
-                timelineFragment?.isFilterSelected = true
-                navigateTo<TimelineFragment>()
+                val bundle = Bundle().apply { putBoolean("isFilterSelected", true) }
+                val timelineFragment = TimelineFragment().apply { arguments = bundle }
+                supportFragmentManager.commit { replace(R.id.fcv_main, timelineFragment) }
             }
-            // 어차피 12시에 점심시간 이벤트 공지 알림 뜨고 누르면 옐로하기로 이동 후 공지 팝업 뜸 따라서 시간에 관계 없이 옐로하기로 이동
             PUSH_TYPE_LUNCH_EVENT -> {
                 binding.bnvMain.menu.getItem(2).isChecked = true
                 navigateTo<YelloFragment>()

--- a/app/src/main/java/com/el/yello/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/MainActivity.kt
@@ -180,6 +180,11 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                 binding.bnvMain.menu.getItem(2).isChecked = true
                 navigateTo<YelloFragment>()
             }
+
+            PUSH_TYPE_FIRST_RECOMMEND -> {
+                binding.bnvMain.menu.getItem(2).isChecked = true
+                navigateTo<YelloFragment>()
+            }
             PUSH_TYPE_RECOMMEND -> {
                 binding.bnvMain.menu.getItem(3).isChecked = true
                 navigateTo<MyYelloFragment>()
@@ -332,6 +337,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         const val PUSH_TYPE_NEW_FRIEND = "NEW_FRIEND"
         const val PUSH_TYPE_VOTE_AVAILABLE = "VOTE_AVAILABLE"
         const val PUSH_TYPE_RECOMMEND = "RECOMMEND"
+        const val PUSH_TYPE_FIRST_RECOMMEND = "FIRST_RECOMMEND"
         const val PUSH_TYPE_OPEN_VOTE = "OPEN_VOTE"
 
         const val BACK_PRESSED_INTERVAL = 2000

--- a/app/src/main/java/com/el/yello/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/MainActivity.kt
@@ -16,11 +16,11 @@ import com.el.yello.databinding.ActivityMainBinding
 import com.el.yello.presentation.event.EventActivity
 import com.el.yello.presentation.main.MainViewModel.Companion.CODE_UNAVAILABLE_EVENT
 import com.el.yello.presentation.main.dialog.notice.NoticeDialog
-import com.el.yello.presentation.main.timeline.TimelineFragment
 import com.el.yello.presentation.main.myyello.MyYelloFragment
 import com.el.yello.presentation.main.myyello.read.MyYelloReadActivity
 import com.el.yello.presentation.main.profile.info.ProfileFragment
 import com.el.yello.presentation.main.recommend.RecommendFragment
+import com.el.yello.presentation.main.timeline.TimelineFragment
 import com.el.yello.presentation.main.yello.YelloFragment
 import com.el.yello.presentation.pay.dialog.PayReSubsNoticeDialog
 import com.el.yello.util.extension.dp
@@ -52,6 +52,8 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
 
     private var backPressedTime: Long = 0
     private var userSubsStateJob: Job? = null
+
+    private var timelineFragment: TimelineFragment? = null
 
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
@@ -176,7 +178,22 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                 navigateTo<ProfileFragment>()
             }
 
-            PUSH_TYPE_VOTE_AVAILABLE, PUSH_TYPE_RECOMMEND -> {
+            PUSH_TYPE_VOTE_AVAILABLE -> {
+                binding.bnvMain.menu.getItem(2).isChecked = true
+                navigateTo<YelloFragment>()
+            }
+            PUSH_TYPE_RECOMMEND -> {
+                binding.bnvMain.menu.getItem(3).isChecked = true
+                navigateTo<MyYelloFragment>()
+            }
+            PUSH_TYPE_OPEN_VOTE -> {
+                binding.bnvMain.menu.getItem(1).isChecked = true
+                // TODO: 내가 보낸 쪽지 필터링 이동하는지 확인
+                timelineFragment?.isFilterSelected = true
+                navigateTo<TimelineFragment>()
+            }
+            // 어차피 12시에 점심시간 이벤트 공지 알림 뜨고 누르면 옐로하기로 이동 후 공지 팝업 뜸 따라서 시간에 관계 없이 옐로하기로 이동
+            PUSH_TYPE_LUNCH_EVENT -> {
                 binding.bnvMain.menu.getItem(2).isChecked = true
                 navigateTo<YelloFragment>()
             }
@@ -296,7 +313,7 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         title = title,
         subTitle = subTitle,
         defaultLottieUrl = animationUrlList[0],
-        openLottieUrl = animationUrlList[1]
+        openLottieUrl = animationUrlList[1],
     )
 
     private fun Event.Reward.toParcelableReward() = ParcelableReward(
@@ -322,6 +339,8 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         const val PUSH_TYPE_NEW_FRIEND = "NEW_FRIEND"
         const val PUSH_TYPE_VOTE_AVAILABLE = "VOTE_AVAILABLE"
         const val PUSH_TYPE_RECOMMEND = "RECOMMEND"
+        const val PUSH_TYPE_LUNCH_EVENT = "LUNCH_EVENT"
+        const val PUSH_TYPE_OPEN_VOTE = "OPEN_VOTE"
 
         const val BACK_PRESSED_INTERVAL = 2000
         const val EXPIRED_DATE_FORMAT = "yyyy-MM-dd"

--- a/app/src/main/java/com/el/yello/presentation/main/MainActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/MainActivity.kt
@@ -53,8 +53,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
     private var backPressedTime: Long = 0
     private var userSubsStateJob: Job? = null
 
-    private var timelineFragment: TimelineFragment? = null
-
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             if (System.currentTimeMillis() - backPressedTime >= BACK_PRESSED_INTERVAL) {
@@ -191,10 +189,6 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
                 val bundle = Bundle().apply { putBoolean("isFilterSelected", true) }
                 val timelineFragment = TimelineFragment().apply { arguments = bundle }
                 supportFragmentManager.commit { replace(R.id.fcv_main, timelineFragment) }
-            }
-            PUSH_TYPE_LUNCH_EVENT -> {
-                binding.bnvMain.menu.getItem(2).isChecked = true
-                navigateTo<YelloFragment>()
             }
         }
     }
@@ -338,14 +332,12 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
         const val PUSH_TYPE_NEW_FRIEND = "NEW_FRIEND"
         const val PUSH_TYPE_VOTE_AVAILABLE = "VOTE_AVAILABLE"
         const val PUSH_TYPE_RECOMMEND = "RECOMMEND"
-        const val PUSH_TYPE_LUNCH_EVENT = "LUNCH_EVENT"
         const val PUSH_TYPE_OPEN_VOTE = "OPEN_VOTE"
 
         const val BACK_PRESSED_INTERVAL = 2000
         const val EXPIRED_DATE_FORMAT = "yyyy-MM-dd"
         const val PAY_RESUBS_DIALOG = "PayResubsNoticeDialog"
         private const val EVENT_CLICK_RECOMMEND_NAVIGATION = "click_recommend_navigation"
-
         private const val TAG_NOTICE_DIALOG = "NOTICE_DIALOG"
 
         @JvmStatic

--- a/app/src/main/java/com/el/yello/presentation/main/timeline/TimelineFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/timeline/TimelineFragment.kt
@@ -41,7 +41,7 @@ class TimelineFragment : BindingFragment<FragmentTimelineBinding>(R.layout.fragm
     private var isScrolled: Boolean = false
     private var isNoFriend: Boolean = false
 
-    var isFilterSelected: Boolean = false
+    private var isFilterSelected: Boolean = false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -102,7 +102,7 @@ class TimelineFragment : BindingFragment<FragmentTimelineBinding>(R.layout.fragm
     }
 
     private fun initFromPushNotification() {
-        isFilterSelected = arguments?.getBoolean("isFilterSelected", false) ?: false
+        isFilterSelected = arguments?.getBoolean(IS_FILTER_SELECTED, false) ?: false
         if (isFilterSelected) {
             binding.tvLookFilterType.text = TYPE_MINE
             binding.tvLookNoFriendTitle.text = stringOf(R.string.look_invite_no_title_mine)
@@ -199,5 +199,6 @@ class TimelineFragment : BindingFragment<FragmentTimelineBinding>(R.layout.fragm
 
         const val TYPE_ALL = "모든 쪽지"
         const val TYPE_MINE = "내가 보낸 쪽지"
+        const val IS_FILTER_SELECTED = "isFilterSelected"
     }
 }

--- a/app/src/main/java/com/el/yello/presentation/main/timeline/TimelineFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/timeline/TimelineFragment.kt
@@ -15,8 +15,8 @@ import com.el.yello.databinding.FragmentTimelineBinding
 import com.el.yello.presentation.main.dialog.invite.InviteFriendDialog
 import com.el.yello.util.extension.BaseLinearRcvItemDeco
 import com.el.yello.util.extension.setPullToScrollColor
-import com.el.yello.util.manager.AmplitudeManager
 import com.el.yello.util.extension.yelloSnackbar
+import com.el.yello.util.manager.AmplitudeManager
 import com.example.ui.base.BindingFragment
 import com.example.ui.extension.setOnSingleClickListener
 import com.example.ui.extension.stringOf
@@ -41,7 +41,7 @@ class TimelineFragment : BindingFragment<FragmentTimelineBinding>(R.layout.fragm
     private var isScrolled: Boolean = false
     private var isNoFriend: Boolean = false
 
-    private var isFilterSelected: Boolean = false
+    var isFilterSelected: Boolean = false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -75,7 +75,8 @@ class TimelineFragment : BindingFragment<FragmentTimelineBinding>(R.layout.fragm
             inviteFriendDialog =
                 InviteFriendDialog.newInstance(viewModel.getYelloId(), TIMELINE_NO_FRIEND)
             AmplitudeManager.trackEventWithProperties(
-                "click_invite", JSONObject().put("invite_view", TIMELINE_NO_FRIEND)
+                "click_invite",
+                JSONObject().put("invite_view", TIMELINE_NO_FRIEND),
             )
             inviteFriendDialog?.show(parentFragmentManager, INVITE_DIALOG)
         }

--- a/app/src/main/java/com/el/yello/presentation/main/timeline/TimelineFragment.kt
+++ b/app/src/main/java/com/el/yello/presentation/main/timeline/TimelineFragment.kt
@@ -49,6 +49,7 @@ class TimelineFragment : BindingFragment<FragmentTimelineBinding>(R.layout.fragm
         initAdapter()
         initInviteBtnListener()
         initFilterBtnListener()
+        initFromPushNotification()
         setListBottomPadding()
         observeTimelinePagingList(isFilterSelected)
         setPullToScrollListener()
@@ -97,6 +98,14 @@ class TimelineFragment : BindingFragment<FragmentTimelineBinding>(R.layout.fragm
                     tvLookNoFriendTitle.text = stringOf(R.string.look_invite_no_title)
                 }
             }
+        }
+    }
+
+    private fun initFromPushNotification() {
+        isFilterSelected = arguments?.getBoolean("isFilterSelected", false) ?: false
+        if (isFilterSelected) {
+            binding.tvLookFilterType.text = TYPE_MINE
+            binding.tvLookNoFriendTitle.text = stringOf(R.string.look_invite_no_title_mine)
         }
     }
 

--- a/build-logic/convention/src/main/kotlin/Constants.kt
+++ b/build-logic/convention/src/main/kotlin/Constants.kt
@@ -3,7 +3,7 @@ object Constants {
     const val compileSdk = 33
     const val minSdk = 28
     const val targetSdk = 33
-    const val versionCode = 41
+    const val versionCode = 42
     const val versionName = "2.0"
     const val jvmVersion = "17"
 }


### PR DESCRIPTION
- closed #419 

## *⛳️ Work Description*
 - 점심시간 이벤트 (매일 12시)
→ 서버에서 12-14시에만 점심시간 이벤트가 뜨도록 보내주므로 시간에 관계없이 알림 클릭 후 그냥 앱 진입, 따로 처리 X
 - 추천인 가입 (열람권 지급)
→ 내 쪽지
 - 누군가 내가 보낸 쪽지를 열람할 때
→ 타임라인 (내가 보낸 쪽지)
- manifest 불필요한 권한 삭제

## *📸 Screenshot*
|                                   점심시간 이벤트                                   |                                      첫 추천인 가입 (열람권 지급)                                         |                                  누군가 내가 보낸 쪽지 열람 시                                  |    
|:---------------------------------------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------:|
| <img width="230px" src="https://github.com/team-yello/YELLO-Android/assets/76741702/b4e9ed82-70c8-4bca-9047-b18c8237d3cf"/> | <img width="230px" src="https://github.com/team-yello/YELLO-Android/assets/76741702/42dbd391-66f7-4c87-bfdb-22a3f1032679"/> | <img width="230px" src="https://github.com/team-yello/YELLO-Android/assets/76741702/68cafb24-ae1d-4a8a-8757-48c47f6b670b"/> | 

## *📢 To Reviewers*
- @team-yello/andro-d 
- 알림 클릭 시 화면 전환 다 확인했습니당

