### PR TITLE
[FIX/#433] Pay / 결제 검증 중 뒤로가기 방지

### DIFF
--- a/app/src/main/java/com/el/yello/presentation/pay/PayActivity.kt
+++ b/app/src/main/java/com/el/yello/presentation/pay/PayActivity.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
@@ -91,6 +92,7 @@ class PayActivity : BindingActivity<ActivityPayBinding>(R.layout.activity_pay) {
         observeCheckInAppValidState()
         initPrivacyBtnListener()
         initServiceBtnListener()
+        setBackPressedWhenLoading()
     }
 
     private fun initView() {
@@ -446,6 +448,17 @@ class PayActivity : BindingActivity<ActivityPayBinding>(R.layout.activity_pay) {
             binding.layoutAdCheckLoading.isVisible = false
         }
         window?.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
+    }
+
+    private fun setBackPressedWhenLoading(){
+        val callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (!manager.isPurchasing.value) {
+                    finish()
+                }
+            }
+        }
+        onBackPressedDispatcher.addCallback(this, callback)
     }
 
     // 서버 오류(500) 시 시스템 다이얼로그 띄우기

--- a/build-logic/convention/src/main/kotlin/Constants.kt
+++ b/build-logic/convention/src/main/kotlin/Constants.kt
@@ -3,7 +3,7 @@ object Constants {
     const val compileSdk = 33
     const val minSdk = 28
     const val targetSdk = 33
-    const val versionCode = 44
+    const val versionCode = 45
     const val versionName = "2.1"
     const val jvmVersion = "17"
 }


### PR DESCRIPTION
- closed #433

## *⛳️ Work Description*
- 결제 검증 중 뒤로가기 방지 설정 (구매 후 검증 중에 뒤로가면 상품 지급이 안됨)
- 버전 코드 2.1(45) 업데이트 완료

## *📢 To Reviewers*
- 재로그인 이슈는 해결할 게 없던걸루...~
- 이번꺼 스토어 올리면 깃허브 Releases도 업데이트하고 Production 브랜치도 업뎃 하시져 ~
